### PR TITLE
Update API docs for setConfigXML

### DIFF
--- a/_posts/2015-04-05-api.md
+++ b/_posts/2015-04-05-api.md
@@ -570,33 +570,41 @@ Retrieve the default config.xml.  This call enables a 3rd party application to g
 
 ##setConfigXML
 
-Associate an custom config.xml file with the current session .  This call returns a token can later be passed as a parameter to a join URL.  When passed as a parameter, the BigBlueButton client will use the associated config.xml for the user (not the default config.xml).  This enables 3rd party applications to provide user-specific config.xml files.
+Associate a custom config.xml file with the current session. This call returns a token that can later be passed as a parameter to a join URL. When passed as a parameter, the BigBlueButton client will use the associated config.xml for the user instead of using the default config.xml. This enables 3rd party applications to provide user-specific config.xml files.
 
 **Resource URL:**
 
-* http&#58;//yourserver.com/bigbluebutton/api/setConfigXML.xml?[parameters]&checksum=[checksum]
+* http&#58;//yourserver.com/bigbluebutton/api/setConfigXML
 
 **Parameters:**
 
 | **Param Name** | **Required / Optional** | **Type** | **Description** |
 |:---------------|:------------------------|:---------|:----------------|
-| meetingID      | Required                | String   | A meetingID to an active meeting. |
+| meetingID      | Required                | String   | A meetingID to an active meeting |
 | configXML      | Required                | String   | A valid config.xml file |
 
 
 **Example Requests:**
 
-The new config.xml is sent as part of a POST request.  The body of the POST request must contain two parameters: meetingID and configXML.  The parameters in the POST request must be signed using the BigBlueButton server's shared secret (salt).
+The config.xml is sent as part of a POST request. The body of the POST request must contain three parameters: `meetingID`, `configXML` and `checksum`. The `meetingID` is the meeting to which this config.xml will be associated to (the meeting must have been created previously), the `configXML` is the content of the config.xml file, and the `checksum` is the signature of this call, calculated in the same way the checksum for other API calls are calculated. However, this API call has no parameters in the URL so the checksum is calculated using a string composed by: method name + parameters in the **body of the request** + shared secret. An example would be:
 
+* Method name: `setConfigXML`
+* Parameters in the body of the request: `configXML=configXML=%3Cconfig%3E%3Clocaleversion+suppressWarning%3D%22false%22%3E0.9.0%3C%2Flocaleversion%3E%3C%2Fmodules%3E%3C%2Fconfig%3E&meetingID=random-8228800`
+* Shared secret: `aae06642a13942004fd83b3ba6e4o9s8`
+* Final string: `setConfigXMLconfigXML=configXML=%3Cconfig%3E%3Clocaleversion+suppressWarning%3D%22false%22%3E0.9.0%3C%2Flocaleversion%3E%3C%2Fmodules%3E%3C%2Fconfig%3E&meetingID=random-8228800aae06642a13942004fd83b3ba6e4o9s8`
 
-See [API source for making call to setConfgXML](https://github.com/bigbluebutton/bigbluebutton/blob/master/bbb-api-demo/src/main/webapp/bbb_api.jsp#L306)
+Notice that the parameters in the body of the request must be ordered alphabetically, otherwise your checksum calculation will not match the calculation done by BigBlueButton. So the `configXML` parameter must come before the `meetingID`. The `checksum` parameter can be at any place.
+
+Another important aspect of this API call is that it has to use the content type `application/x-www-form-urlencoded`, otherwise the parameters will not be detected by BigBlueButton.
+
+See also this [API source example](https://github.com/bigbluebutton/bigbluebutton/blob/09c4ffcbe16fcf4fc79ae8979641f5ffdc4bf17a/bbb-api-demo/src/main/webapp/bbb_api.jsp#L335) from the API demos for making a call to setConfigXML.
 
 **Example Response:**
 
 ```xml
   <response>
       <returncode>SUCCESS</returncode>
-      <token>asdfl234kjasdfsadfy</token>
+      <token>6lwBf1TX</token>
   </response>
 ```
 


### PR DESCRIPTION
To make two points more clear:
- The POST request has to use the content type `application/x-www-form-urlencoded`
- The parameters in the body of the POST request have to be ordered alphabetically
