### PR TITLE
Fix typos in the description of setConfigXML

### DIFF
--- a/_posts/2015-04-05-api.md
+++ b/_posts/2015-04-05-api.md
@@ -586,9 +586,9 @@ Associate a custom config.xml file with the current session. This call returns a
 The config.xml is sent as part of a POST request. The body of the POST request must contain three parameters: `meetingID`, `configXML` and `checksum`. The `meetingID` is the meeting to which this config.xml will be associated to (the meeting must have been created previously), the `configXML` is the content of the config.xml file, and the `checksum` is the signature of this call, calculated in the same way the checksum for other API calls are calculated. However, this API call has no parameters in the URL so the checksum is calculated using a string composed by: method name + parameters in the **body of the request** + shared secret. An example would be:
 
 * Method name: `setConfigXML`
-* Parameters in the body of the request: `configXML=configXML=%3Cconfig%3E%3Clocaleversion+suppressWarning%3D%22false%22%3E0.9.0%3C%2Flocaleversion%3E%3C%2Fmodules%3E%3C%2Fconfig%3E&meetingID=random-8228800`
+* Parameters in the body of the request: `configXML=%3Cconfig%3E%3Clocaleversion+suppressWarning%3D%22false%22%3E0.9.0%3C%2Flocaleversion%3E%3C%2Fmodules%3E%3C%2Fconfig%3E&meetingID=random-8228800`
 * Shared secret: `aae06642a13942004fd83b3ba6e4o9s8`
-* Final string: `setConfigXMLconfigXML=configXML=%3Cconfig%3E%3Clocaleversion+suppressWarning%3D%22false%22%3E0.9.0%3C%2Flocaleversion%3E%3C%2Fmodules%3E%3C%2Fconfig%3E&meetingID=random-8228800aae06642a13942004fd83b3ba6e4o9s8`
+* Final string: `setConfigXMLconfigXML=%3Cconfig%3E%3Clocaleversion+suppressWarning%3D%22false%22%3E0.9.0%3C%2Flocaleversion%3E%3C%2Fmodules%3E%3C%2Fconfig%3E&meetingID=random-8228800aae06642a13942004fd83b3ba6e4o9s8`
 
 Notice that the parameters in the body of the request must be ordered alphabetically, otherwise your checksum calculation will not match the calculation done by BigBlueButton. So the `configXML` parameter must come before the `meetingID`. The `checksum` parameter can be at any place.
 


### PR DESCRIPTION
Was using `configXML=configXML=` in the parameters when it should be `configXML=` only.
