### PR TITLE
No need for sudo to in Flex install as the current user is the owner of his home directory

### DIFF
--- a/_posts/2015-09-18-10setup.md
+++ b/_posts/2015-09-18-10setup.md
@@ -172,9 +172,9 @@ ant -f frameworks/build.xml thirdparty-downloads
 After Flex downloads the remaining third-party tools, you need to modify their permissions.
 
 ```
-sudo find ~/dev/tools/apache-flex-sdk-4.13.0-bin -type d -exec chmod o+rx '{}' \;
+find ~/dev/tools/apache-flex-sdk-4.13.0-bin -type d -exec chmod o+rx '{}' \;
 chmod 755 ~/dev/tools/apache-flex-sdk-4.13.0-bin/bin/*
-sudo chmod -R +r ~/dev/tools/apache-flex-sdk-4.13.0-bin
+chmod -R +r ~/dev/tools/apache-flex-sdk-4.13.0-bin
 ```
 
 Next, create a linked directory with a shortened name for easier referencing.
@@ -197,9 +197,9 @@ The last step to have a working Flex SDK is to configure it to work with playerg
 
 ```
 cd ~/dev/tools/apache-flex-sdk-4.13.0-bin
-sudo sed -i "s/11.1/11.2/g" frameworks/flex-config.xml
-sudo sed -i "s/<swf-version>14<\/swf-version>/<swf-version>15<\/swf-version>/g" frameworks/flex-config.xml
-sudo sed -i "s/{playerglobalHome}\/{targetPlayerMajorVersion}.{targetPlayerMinorVersion}/libs\/player\/11.2/g" frameworks/flex-config.xml
+sed -i "s/11.1/11.2/g" frameworks/flex-config.xml
+sed -i "s/<swf-version>14<\/swf-version>/<swf-version>15<\/swf-version>/g" frameworks/flex-config.xml
+sed -i "s/{playerglobalHome}\/{targetPlayerMajorVersion}.{targetPlayerMinorVersion}/libs\/player\/11.2/g" frameworks/flex-config.xml
 ```
 
 With the tools installed, you need to add a set of environment variables to your `.profile` to access these tools.


### PR DESCRIPTION
The `sudo` prefixed commands when configuring Flex install are likely to create permission issues with the flex install directory like in the following ticket https://github.com/bigbluebutton/bigbluebutton/issues/3014

Running them without `sudo` is fine.

Tested and working under my new VM.
