### PR TITLE
Add docs for Office365 OAuth

### DIFF
--- a/_posts/2018-06-22-greenlight-v2.md
+++ b/_posts/2018-06-22-greenlight-v2.md
@@ -347,8 +347,10 @@ TWITTER_SECRET=elxXJZqPVexBFf9ZJsafd4UTSzpr5AVmcH7Si5JzeHQ9th
 ### Office365 OAuth2
 
 You will need an Office365 account to create an OAuth 2 key and secret. This will allow Greenlight users to authenticate with their own Office365 accounts.
-Head to the following site and sign in to your Office365 account:
+
+To begin, head over to the following site and sign in to your Office365 account:
 [https://developer.microsoft.com/en-us/graph](https://developer.microsoft.com/en-us/graph)
+
 Click on the tab that says “My Apps” and you should get redirected to the applications portal:
 
 ![](https://d2mxuefqeaa7sj.cloudfront.net/s_862F4C65DCBBF32F66208EA7FF25C153F80CC5FED653F7FCC2E693F7C7577A33_1539186511422_image.png)


### PR DESCRIPTION
Adding docs for the Office365 omniauthentication feature. This should be added only after the following has been closed:
https://github.com/bigbluebutton/greenlight/issues/291