### PR TITLE
Update and rearrange 2.2 HTML5 documentation, restore dev docs, legacy docs

### DIFF
--- a/_pages/html5-best-practices.md
+++ b/_pages/html5-best-practices.md
@@ -1,0 +1,1 @@
+../_posts/2019-07-26-html5-best-practices.md

--- a/_pages/legacy-dev.md
+++ b/_pages/legacy-dev.md
@@ -1,0 +1,1 @@
+../_posts/2019-07-29-22-legacy-dev.md

--- a/_posts/2015-04-05-html5-accessibility.md
+++ b/_posts/2015-04-05-html5-accessibility.md
@@ -9,9 +9,6 @@ order: 1
 
 # Overview 
 
-The province of Ontario is one of the first in establishing a goal and time-frame for accessibility. The BigBlueButton project aims to comply with the proposed accessibility guidelines, enabling individuals 
-with disabilities the ability to use the web application. To be a bit more specific, we ensure that users are able to perceive, understand, navigate, interact and contribute using the HTML5 client.
-
 Based on the scope of the project, focus has been placed on disabilities related to visual, auditory and motor impairments. 
 We have designed the BigBlueButton HTML5 client to be accessible to as many users as possible regardless of any underlying disability.
 
@@ -21,85 +18,129 @@ Keyboard and screen reader support has been implemented, in particular for the o
 ***Note:
 There are a few minor controls within the client that are not fully accessible, The colour picker in the closed caption settings for example.***
 
-#### Keyboard Example : Send a Public message when client first loads
+# Accessibility
 
-* Close audio modal
-  1. Tab
-  2. Enter
-* Open users pane
-  1. Tab
-  2. Enter
-* Focus messages list
-  1. Shift + Tab (x2)
-* Open Public chat
-  1. Down-Arrow
-  2. Enter
-* Send message
-  1. Type message
-  2. Enter
+When dealing with web accessibility there are a few key factors we must keep in mind while developing
 
-## NVDA 
+  1. Tab Order
+  2. Color Contrast
+  3. Focus
+  4. Semantics
+  5. Testing
 
-NVDA navigation keys:
-Stop Reading                    -  Ctrl
-Activate Link                   -  Enter
-Activate Button                 -  Enter or Space
-Go to next Heading              -  H
-Go to next landmark/region      -  D
-Go to next list                 -  L
-Go to next list item            -  I
+## Tab Order
 
-A more comprehensive list of NVDA short cuts can be found at : http://webaim.org/resources/shortcuts/nvda
-Due to browser limitations the dialog box to join Mic audio is currently not keyboard accessible. The colour picker in the closed caption settings is also currently not keyboard accessible. There are a few other minor controls yet to be made accessible.
+The goal when implementing the tab order is ensuring the elements in the  tab sequence are logical and simple.
 
-***Note: NVDA works best with Mozilla FireFox and users must toggle focus mode off by pressing the ESC key or NVDAKEY + Spacebar to switch to Browse mode.***
+When a user presses the tab key focus should move to the next interactable element. If the user continues to press the tab key, focus should move in a logical order through all the interactable elements on the page. The tab focus should be visually identified, currently the HTML5 client adds a thin border to the field, when tab is pressed focus is seen to visibly move.
 
-#### NVDA Example : Send a Public message when client first loads 
+***Note: A number of users including the following.***
 
-* Close audio modal
-  1. b
-  2. Shift + b
-  2. Enter
-* Open users pane
-  1. b
-  2. Shift + b
-  3. Enter
-* Focus messages list
-  1. Shift + d (x2)
-* Open Public chat
-  1. Down-Arrow
-  2. Enter
-* Send message
-  1. Type message
-  2. Enter
+  * ***Those with visual impairments, who rely on screen readers or screen magnifiers.***
+  * ***Those with limited dexterity, who depend on the use of the keyboard to using a mouse.***
+  * ***Those who can only utilize a single switch to control a computer.***
+
+***will all navigate through a page by using the tab button.***
 
 
-## JAWS
+The order of elements in the DOM determine their place in the tab order, for elements that should receive focus. Elements that don’t natively receive focus can be inserted into the tab order by adding a tabindex=”0” property.
 
-Common Navigation Shortcut keys:
+***Caution:***
+***When using the tabindex property, positive values should generally be avoided because it places elements outside of the natural tab order, this can present issues for screen reader users who rely on navigating the DOM through a linear manner.***
 
-JAWS shortcuts resource
+The following extension gives a visual representation of the tab order of a current web document.
 
-***Note: JAWS users must ensure that cursor mode is toggled off by pressing JAWSKEY + z, in order to interact with users in the userlist. By default, the JAWSKEY is set to the insert key on the keyboard.***
+### ChromeLens
+offered by ngzhian
 
-### JAWS Example : Send a Public message when client first loads
+![Contrast Ratio Calculator](/images/accessibility_chromelense.jpg)
+https://chrome.google.com/webstore/detail/chromelens/idikgljglpfilbhaboonnpnnincjhjkd?hl=en
 
-* Close audio modal
-  1. b
-  2. Shift + b
-  3. Enter
-* Open users pane
-  1. Tab
-  2. Shift + Enter
-* Focus messages list
-  1. Shift + Tab (x2)
-* Open Public chat
-  1. Insert + z
-  2. Down arrow
-  2. Enter
-* Send message
-  1. Type message
-  2. Enter
 
-The following link provides a listing of JAWS keys and functionality:
-[JAWS Keys](https://webaim.org/resources/shortcuts/jaws)
+## Focus
+
+
+## Color Contrast
+
+When dealing with color contrast we are talking about finding colors for a scheme that not only implement maximum contrast, but gives the appropriate contrast between the content and its background for those who experience low visual impairments, color deficiencies or the loss of contrast typically accompanied by aging.
+
+The HTML5 client ensures that all visual designs meet the minimum color-contrast ratio for both normal as well as large text on a background, described by the WCAG 2.0 AA standards.  “Contrast (Minimum): Understanding Success Criterion 1.4.3.” 
+
+To make sure that we have met these guidelines, there are numerous tools available online which allow the comparison of foreground and background colors using hex values, to see if they fall within the appropriate contrast ratio.
+
+![Contrast Ratio Calculator](/images/accessibility_colorchecker.jpg)
+http://webaim.org/resources/contrastchecker/
+
+
+### Currently implemented colors:
+
+![Currently implemented element colors](/images/accessibility_colors1.jpg)
+![Currently implemented typography colors](/images/accessibility_colors2.jpg)
+ 
+* Blue - primary color - action buttons
+* Red - closing audio, indicators and error alerts
+* Green - audio indicator, success alert, check marks
+* Orange - warning alerts
+* Dark Blue - Headings
+* Grey - base typography color
+
+
+***Note:***
+***The ChromeLense extension also provides the ability to view your browser using different personas of users who may view web content with various different visual impairments. This is particularly useful when deciding on appropriate color schemes to best suit a wider range of users.***
+
+
+## Semantics
+
+Users with visual disabilities can miss out on visual affordances. We need to make sure the information we are trying to express, is expressed in a way that flexible enough so assistive technology can pick up on it; creating an alternative interface for our users. we refer to this as expressing the semantics of an element.
+
+The HTML5 client uses the WAI-ARIA (Web Accessibility Initiative – Accessible Rich Internet Applications) to provide access to screen readers. The following list of commonly used aria attributes:
+
+  * aria-role
+  * aria-label
+  * aria-labelledby
+  * aria-describedby
+  * aria-hidden
+  * aria-live
+  * aria-expanded
+  * aria-haspopup
+
+#### Links
+  
+  HTML5 ARIA spec - http://www.w3.org/TR/aria-in-html/
+
+  ARIA spec - http://www.w3.org/WAI/PF/aria/
+  
+  Roles - http://www.w3.org/TR/wai-aria/roles
+  
+  States and Properties - http://www.w3.org/TR/wai-aria/states_and_properties
+  
+  Design Patterns - http://www.w3.org/TR/wai-aria-practices/#aria_ex
+
+
+### Testing
+
+Testing for accessibility can be a somewhat painful process, if you try to manually find and fix all the issues. While it is good practice to go through a checklist and ensure all elements in the HTML5 client meet their accessibility requirements, this process can be very slow and time consuming. For this reason it is suggested to use an automated accessibility auditor first.
+
+#### aXe
+offered by Deque Systems
+
+![aXe](/images/accessibility_axe.jpg)
+https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd
+
+#### Accessibility Developer Tools
+offered by Google Accessibility
+
+![Accessibility Developer Tools](/images/accessibility_audit.jpg)
+https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb
+
+Both of these extensions provide the ability to scan the DOM and report on any accessibility issues based on levels which can be set, weather AA or AAA standards. For the purposes of the HTML5 client we follow the AA guidelines. Any reported errors also come with a listing of potential fixes.
+
+***Note:***
+***Once these extensions are installed to the browser they must be run from inside the console.***
+
+
+## Training
+
+We recommenbd checking out this [free online accessibility course](http://www.udacity.com/course/web-accessibility--ud891) which can provide a very good understanding of the basics of dealing with web accessibility for both developers and designers. 
+
+In the event you do not need to take the course but would still like access to the information as reference, the course is also found in [full document form](https://developers.google.com/web/fundamentals/accessibility) . It is a live document which is updated by the developers over at Google.

--- a/_posts/2015-04-05-html5-overview.md
+++ b/_posts/2015-04-05-html5-overview.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Overview"
+title: "HTML5 Overview"
 #category: html
 redirect_from: "/labs/html5-overview"
 date: 2015-04-05 11:41:36
@@ -20,7 +20,7 @@ Also, while Flash enjoys support from a wide range of browsers (FireFox, Chrome,
 
 We want to move the BigBlueButton project to pure HTML5 and support mobile users _long_ before the end of 2020.  Hence, the HTML5 client project.
 
-A BigBlueButton 2.0-beta server (hereafter referred to as simply "BigBlueButton 2.0")  can support users connecting from either the Flash or HTML5 client in the same sessions.  The server routes messages seamlessly between the clients. 
+A BigBlueButton 2.0 server can support users connecting from either the Flash or HTML5 client in the same sessions.  The server routes messages seamlessly between the clients. 
 
 The HTML5 support for real-time audio and video has substantially improved of the years with WebRTC.  The Flash client already uses WebRTC for sending and receiving high-quliaty audio for the audio (with a fallback to built-in Flash audio if the network blocks the ports needed for WebRTC).
 
@@ -86,7 +86,7 @@ With the above it's now possible to hold a fairly complete meeting with just the
 
 # Future Releases
 
-Building upon the first release, we plan to add the remaining presenter and moderator capabilities to the HTML5 client, including:
+Building upon the first release, the 2.2-beta adds the remaining presenter and moderator capabilities to the HTML5 client, including:
 
   * Remaining whiteboard controls (pan/zoom)
   * Breakout Rooms

--- a/_posts/2015-09-22-architecture.md
+++ b/_posts/2015-09-22-architecture.md
@@ -18,21 +18,26 @@ The following diagram provides a high-level overview of the BigBlueButton archit
 
 We'll break down each component below.
 
-### Client
+## HTML5 Client and Server
 
-The Client is a Flash application which runs inside the browser. The client connects to Red5 using RTMP (port 1935) or RTMPT (port 80) if needs to tunnel.
-When it needs to connect using RTMPT, it connects through Nginx which proxies the connection to Red5.
+The HTML5 client is a single page, responsive web application that is built upon the following components: 
+  * [React.js](https://facebook.github.io/react/) for rendering the user interface in an efficient manner
+  * [WebRTC](https://webrtc.org/) for sending/receiving audio and video
 
-The Client also uploads presentations to Web API.
+The HTML5 server is built upon
+  * [Meteor.js](http://meteor.com) in [ECMA2015](http://www.ecma-international.org/ecma-262/6.0/)
+for communication between client and server.
+  * [MongoDB](https://www.mongodb.com/) for keeping the state of each BigBlueButton client consistent with the BigBlueButton server
 
+The MongoDB database contains information about all meetings on the server and, in turn, each client connected to a meeting. Each user's client is only aware of the their meeting's state, such the user's public and private chat messages sent and received. The client side subscribes to the published collections on the server side. Updates to MongoDB on the server side are automatically pushed to MiniMongo on the client side.
 
-### HTML5 Client and Server
+The following diagram gives an overview of the architecture of the HTML5 client and its communications with the other components in BigBlueButton.
 
-The HTML5 client and server is built using [Meteor](https://www.meteor.com/) and communicates with the other components of the system through redis pubsub. 
+![HTML5 Overview](/images/html5-client-architecture.png)
 
-See the [HTML5 Overview](/html/html5-overview.html) document for more info.
+More information on the architecture of the HTML5 client can be found [here](/html5-overview.html).
 
-### BBB Web 
+## BBB Web 
 
 The Web [API](/dev/api.html) provides the integration endpoint for third-party applications -- such as Moodle, Wordpress, Canvas, Sakai, etc. -- to control the BigBlueButton server. 
 
@@ -40,19 +45,15 @@ Every access to BigBlueButton comes through a front-end portal (we refer to as a
 
 The BigBlueButton comes with some simple [API demos](http://demo.bigbluebutton.org/demo/demo1.jsp).  Regardless of which front-end you use, they all use the [API](/dev/api.html) under the hood.
 
-### Presentation Conversion
-
-Uploaded presentations undergoes conversion process in order to be displayed in the Flash client. If the uploaded file is an Office document, it gets converted into PDF using LibreOffice and then converted to SWF using SWFTools. The conversion process is described later in this page.
-
-### Redis PubSub
+## Redis PubSub
 
 Redis PubSub provides a communication channel between different applications running on the BigBlueButton server.
 
-### Redis DB
+## Redis DB
 
 When a meeting is recorded, all events are stored in Redis DB. When the meeting ends, the Recording Processor will take all the recorded events as well as the different raw (PDF, WAV, FLV) files for processing.
 
-### Red5 Apps (Screenshare, Apps, Voice, Video)
+## Red5 Apps (Screenshare, Apps, Voice, Video)
 
 We think Red5 rocks! (We just had to get that upfront).
 
@@ -80,7 +81,7 @@ FreeSWITCH to easily create their own integration. Communication between apps an
 ![FsESL Akka architecture](/images/10/fsesl-akka-arch.png)
 
 
-### FreeSWITCH
+## FreeSWITCH
 
 We think FreeSWITCH rocks too!
 
@@ -101,7 +102,7 @@ Uploaded presentations go through a conversion process in order to be displayed 
 
 The conversion process sends progress messages to the client through the Redis pubsub.
 
-### Presentation conversion flow
+## Presentation conversion flow
 
 The diagram below describes the flow of the presentation conversion. We take in consideration the configuration for enabling and disabling SWF, SVG and PNG conversion.
 
@@ -117,6 +118,6 @@ And finally, the SWF conversion flow. We cover it too with its fallback conversi
 
 ## BigBlueButton Client
 
-BigBlueButton client runs inside the browser. The main application is in ActionScript. There are Javascript libraries that provides connection to FreeSWITCH, launch the screen sharing applet, etc. The Flash client connects to BigBlueButton App to send and receive messages. The client internally uses an event bus for the components to talk to each other.
+BigBlueButton Flash client runs inside the browser. The main application is in ActionScript. There are Javascript libraries that provides connection to FreeSWITCH, launch the screen sharing applet, etc. The Flash client connects to BigBlueButton App to send and receive messages. The client internally uses an event bus for the components to talk to each other. The client connects to Red5 using RTMP (port 1935) or RTMPT (port 80) if needs to tunnel. When it needs to connect using RTMPT, it connects through Nginx which proxies the connection to Red5.
 
 ![Client Architecture](/images/10/bbb-client-arch.png)

--- a/_posts/2019-02-14-customize.md
+++ b/_posts/2019-02-14-customize.md
@@ -698,9 +698,13 @@ To change the favicon, overwrite the file `/var/www/bigbluebutton-default/favico
 
 You'll need to update file each time the `bbb-config` package updates.
 
+# HTML5 client configuration 
+
+The configuration file for the HTML5 client is located in `/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml`.  It contains all the settings for the HTML5 client.  
+
 ## Change title in the HTML5 client
 
-To change the title, edit `/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml` and change the entry for `public.app.clientTitle`
+To change the title, edit `settings.yml` and change the entry for `public.app.clientTitle`
 
 ~~~
 public:
@@ -717,388 +721,93 @@ yq w -i $TARGET public.app.clientTitle "New Title"
 chown meteor:meteor $TARGET
 ~~~
 
+## Send client logs to the server
 
-# HTML5 client configuration 
+To assist with monitoring and debugging, the HTML5 client can send its logs to the BigBlueButton server via the `logger` function.  Here's an example of its use:
 
-The configuration file for the HTML5 client is located in `/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml`.  It contains all the settings for the HTML5 client.  
+The client logger accepts three targets for the logs: `console`, `server` and `external`.
 
-Here's a sample `settings.yml` file (with a description of some of the key values below it).
+
+Name | Default Value |Accepted Values| Description 
+ --- | --- | ---| ---
+target | "console" | "console", "external", "server" | Where the logs will be sent to.
+level | "info"  | "debug", "info", "warn", "error" | The lowest log level that will be sent. Any log level higher than this will also be sent to the target. 
+url | - | - | The end point where logs will be sent to when the target is set to "external".
+method | - | "POST", "PUT" | HTTP method being used when using the target "external".
+
+The default values are: 
 
 ~~~
-public:
-  app:
-    mobileFontSize: 16px
-    desktopFontSize: 14px
-    audioChatNotification: false
-    showParticipantsOnLogin: true
-    autoJoin: true
-    listenOnlyMode: true
-    forceListenOnly: false
-    skipCheck: false
-    clientTitle: BigBlueButton
-    appName: BigBlueButton HTML5 Client
-    bbbServerVersion: 2.2-dev
-    copyright: ©2019 BigBlueButton Inc.
-    html5ClientBuild: 514
-    helpLink: https://bigbluebutton.org/html5/
-    lockOnJoin: true
-    cdn: ""
-    basename: /html5client
-    askForFeedbackOnLogout: true
-    allowUserLookup: false
-    enableNetworkInformation: false
-    defaultSettings:
-      application:
-        animations: true
-        chatAudioAlerts: false
-        chatPushAlerts: false
-        fallbackLocale: en
-      audio:
-        inputDeviceId: undefined
-        outputDeviceId: undefined
-      dataSaving:
-        viewParticipantsWebcams: true
-        viewScreenshare: true
-      participants:
-        muteAll: false
-        lockAll: false
-        microphone: false
-        publicChat: false
-        privateChat: false
-        layout: false
-    shortcuts:
-      openOptions:
-        accesskey: O
-        descId: openOptions
-      toggleUserList:
-        accesskey: U
-        descId: toggleUserList
-      toggleMute:
-        accesskey: M
-        descId: toggleMute
-      joinAudio:
-        accesskey: J
-        descId: joinAudio
-      leaveAudio:
-        accesskey: L
-        descId: leaveAudio
-      togglePublicChat:
-        accesskey: P
-        descId: togglePublicChat
-      hidePrivateChat:
-        accesskey: H
-        descId: hidePrivateChat
-      closePrivateChat:
-        accesskey: G
-        descId: closePrivateChat
-      openActions:
-        accesskey: A
-        descId: openActions
-      openStatus:
-        accesskey: S
-        descId: openStatus
-    branding:
-      displayBrandingArea: false
-    allowHTML5Moderator: true
-    httpsConnection: false
-    connectionTimeout: 60000
-    showHelpButton: true
-    enableExternalVideo: true
-    effectiveConnection:
-    - critical
-    - danger
-    - warning
-  kurento:
-    wsUrl: wss://bbb.example.com/bbb-webrtc-sfu
-    chromeDefaultExtensionKey: akgoaoikmbmhcopjgakkcepdgdgkjfbc
-    chromeDefaultExtensionLink: https://chrome.google.com/webstore/detail/bigbluebutton-screenshare/akgoaoikmbmhcopjgakkcepdgdgkjfbc
-    chromeExtensionKey: KEY
-    chromeExtensionLink: LINK
-    chromeScreenshareSources:
-    - window
-    - screen
-    firefoxScreenshareSource: window
-    cameraProfiles:
-    - id: low
-      name: Low quality
-      default: false
-      constraints:
-        width:
-          max: 160
-        height:
-          max: 120
-    - id: medium
-      name: Medium quality
-      default: true
-      constraints:
-        width:
-          max: 320
-        height:
-          max: 240
-    - id: high
-      name: High quality
-      default: false
-      constraints:
-        width:
-          max: 640
-        height:
-          max: 480
-    - id: hd
-      name: High definition
-      default: false
-      constraints:
-        width:
-          max: 1280
-        height:
-          max: 960
-    enableScreensharing: true
-    enableVideo: true
-    enableVideoStats: false
-    enableVideoMenu: true
-    enableListenOnly: true
-    autoShareWebcam: false
-  allowOutsideCommands:
-    toggleRecording: false
-    toggleSelfVoice: false
-  poll:
-    max_custom: 5
-  captions:
-    enabled: false
-    backgroundColor: '#000000'
-    fontColor: '#FFFFFF'
-    fontFamily: Calibri
-    fontSize: 24px
-    takeOwnership: true
-    lines: 2
-    time: 5000
-  chat:
-    min_message_length: 1
-    max_message_length: 5000
-    grouping_messages_window: 10000
-    type_system: SYSTEM_MESSAGE
-    type_public: PUBLIC_ACCESS
-    type_private: PRIVATE_ACCESS
-    system_userid: SYSTEM_MESSAGE
-    system_username: SYSTEM_MESSAGE
-    public_id: public
-    public_group_id: MAIN-PUBLIC-GROUP-CHAT
-    public_userid: public_chat_userid
-    public_username: public_chat_username
-    storage_key: UNREAD_CHATS
-    system_messages_keys:
-      chat_clear: PUBLIC_CHAT_CLEAR
-  note:
-    enabled: true
-    url: https://bbb.example.com/pad
-    config:
-      showLineNumbers: false
-      showChat: false
-      noColors: true
-      showControls: true
-      rtl: false
-  layout:
-    autoSwapLayout: false
-    hidePresentation: false
-  media:
-    stunTurnServersFetchAddress: /bigbluebutton/api/stuns
-    mediaTag: '#remote-media'
-    callTransferTimeout: 5000
-    callHangupTimeout: 2000
-    callHangupMaximumRetries: 10
-    echoTestNumber: "9196"
-  presentation:
-    defaultPresentationFile: default.pdf
-    uploadEndpoint: /bigbluebutton/presentation/upload
-    uploadSizeMin: 0
-    uploadSizeMax: 50000000
-    uploadValidMimeTypes:
-    - extension: .pdf
-      mime: application/pdf
-    - extension: .doc
-      mime: application/msword
-    - extension: .docx
-      mime: application/vnd.openxmlformats-officedocument.wordprocessingml.document
-    - extension: .xls
-      mime: application/vnd.ms-excel
-    - extension: .xlsx
-      mime: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
-    - extension: .ppt
-      mime: application/vnd.ms-powerpoint
-    - extension: .pptx
-      mime: application/vnd.openxmlformats-officedocument.presentationml.presentation
-    - extension: .txt
-      mime: text/plain
-    - extension: .rtf
-      mime: application/rtf
-    - extension: .odt
-      mime: application/vnd.oasis.opendocument.text
-    - extension: .ods
-      mime: application/vnd.oasis.opendocument.spreadsheet
-    - extension: .odp
-      mime: application/vnd.oasis.opendocument.presentation
-    - extension: .odg
-      mime: application/vnd.oasis.opendocument.graphics
-    - extension: .odc
-      mime: application/vnd.oasis.opendocument.chart
-    - extension: .odi
-      mime: application/vnd.oasis.opendocument.image
-    - extension: .jpg
-      mime: image/jpeg
-    - extension: .png
-      mime: image/png
-  user:
-    role_moderator: MODERATOR
-    role_viewer: VIEWER
-    role_presenter: PRESENTER
-  whiteboard:
-    annotations:
-      status:
-        start: DRAW_START
-        update: DRAW_UPDATE
-        end: DRAW_END
-    toolbar:
-      multiUserPenOnly: false
-      colors:
-      - label: black
-        value: '#000000'
-      - label: white
-        value: '#ffffff'
-      - label: red
-        value: '#ff0000'
-      - label: orange
-        value: '#ff8800'
-      - label: eletricLime
-        value: '#ccff00'
-      - label: Lime
-        value: '#00ff00'
-      - label: Cyan
-        value: '#00ffff'
-      - label: dodgerBlue
-        value: '#0088ff'
-      - label: blue
-        value: '#0000ff'
-      - label: violet
-        value: '#8800ff'
-      - label: magenta
-        value: '#ff00ff'
-      - label: silver
-        value: '#c0c0c0'
-      thickness:
-      - value: 14
-      - value: 12
-      - value: 10
-      - value: 8
-      - value: 6
-      - value: 4
-      - value: 2
-      - value: 1
-      font_sizes:
-      - value: 36
-      - value: 32
-      - value: 28
-      - value: 24
-      - value: 20
-      - value: 16
-      tools:
-      - icon: text_tool
-        value: text
-      - icon: line_tool
-        value: line
-      - icon: circle_tool
-        value: ellipse
-      - icon: triangle_tool
-        value: triangle
-      - icon: rectangle_tool
-        value: rectangle
-      - icon: pen_tool
-        value: pencil
-      - icon: hand
-        value: hand
-      presenterTools:
-      - text
-      - line
-      - ellipse
-      - triangle
-      - rectangle
-      - pencil
-      - hand
-      multiUserTools:
-      - text
-      - line
-      - ellipse
-      - triangle
-      - rectangle
-      - pencil
-      - hand
   clientLog:
-    server:
-      enabled: true
-      level: info
-    console:
-      enabled: true
-      level: debug
-    external:
-      enabled: true
-      level: info
-      url: https://bbb.example.com/html5log
-      method: POST
-      throttleInterval: 400
-private:
-  app:
-    host: 127.0.0.1
-    port: 3000
-    localesUrl: /locales
-    pencilChunkLength: 100
-    loadSlidesFromHttpAlways: false
-  etherpad:
-    apikey: f7cdaaa3ffcc36f3b8261bcdb99101367c3e87f8cde9b40a91fb027022e39cf4
-    version: 1.2.13
-    host: 127.0.0.1
-    port: 9001
-  redis:
-    host: 127.0.0.1
-    port: "6379"
-    timeout: 5000
-    password: null
-    debug: false
-    channels:
-      toAkkaApps: to-akka-apps-redis-channel
-      toThirdParty: to-third-party-redis-channel
-    subscribeTo:
-    - to-html5-redis-channel
-    - from-akka-apps-*
-    - from-third-party-redis-channel
-    - from-etherpad-redis-channel
-    async:
-    - from-akka-apps-wb-redis-channel
-    ignored:
-    - CheckAlivePongSysMsg
-    - DoLatencyTracerMsg
-  serverLog:
-    level: info
-  minBrowserVersions:
-  - browser: chrome
-    version: 59
-  - browser: firefox
-    version: 52
-  - browser: firefoxMobile
-    version: 52
-  - browser: edge
-    version: 17
-  - browser: ie
-    version: Infinity
-  - browser: mobileSafari
-    version:
-    - 11
-    - 1
-  - browser: opera
-    version: 46
-  - browser: safari
-    version:
-    - 11
-    - 1
-  - browser: electron
-    version:
-    - 0
-    - 36
+    server: { enabled: true, level: info }
+    console: { enabled: true, level: debug }
+    external: { enabled: false, level: info, url: https://LOG_HOST/html5Log, method: POST, throttleInterval: 400, flushOnClose: true }
+~~~
+
+Notice that the `external` option is disabled by default - you can enable it on your own server after a few configuration changes.
+
+When setting the output to `external`, the BigBlueButton client will POST the log events to the URL endpoint provided by `url`. To create an associated endpoint on the BigBlueButton server for the POST request, create a file `/etc/bigbluebutton/nginx/client-log.nginx` with the following contents:
+
+~~~
+location /html5Log {
+	access_log /var/log/nginx/html5-client.log postdata;
+	echo_read_request_body;
+}
+~~~
+
+Then create a file in `/etc/nginx/conf.d/client-log.conf` with the following contents:
+
+~~~
+log_format postdata '$remote_addr [$time_iso8601] $request_body';
+~~~
+
+Next, install the full version of nginx.
+
+~~~
+sudo apt-get install nginx-full
+~~~
+
+You may also need to create the external output file and give it the appropriate permissions and ownership:
+
+~~~
+sudo touch /var/log/nginx/html5-client.log
+sudo chown www-data:adm /var/log/nginx/html5-client.log
+sudo chmod 640 /var/log/nginx/html5-client.log
+~~~
+
+Restart BigBlueButton with `sudo bbb-conf --restart` and launch the BigBlueButton HTML5 client in a new session.  You should see the logs appearing in `/var/log/nginx/html5-client.log` as follows
+
+~~~
+99.239.102.0 [2018-09-09T14:59:10+00:00] [{\x22name: .. }]
+~~~
+
+You can follow the logs on the server with the command
+
+~~~
+tail -f html5-client.log | sed -u -e 's/\\x22/"/g' -e 's/\\x5C/\\/g'
+~~~
+
+Here's a sample log entry
+
+~~~javascript
+{  
+   "name":"clientLogger",
+   "level":30,
+   "levelName":"info",
+   "msg":"[audio] iceServers",
+   "time":"2018-08-27T19:32:57.389Z",
+   "src":"https://demo.bigbluebutton.org/html5client/dfe4ad6bfad11b20d1904e76e71d385262781887.js?meteor_js_resource=true:147:782083",
+   "v":1,
+   "extraInfo":{  
+      "sessionToken":"e7boenucj1pwkbfc",
+      "meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1535398242909",
+      "requesterUserId":"w_klfavdlkumj8",
+      "fullname":"Ios",
+      "confname":"Demo Meeting",
+      "externUserID":"w_klfavdlkumj8"
+   },
+   "url":"https://demo.bigbluebutton.org/html5client/users",
+   "userAgent":"Mozilla/5.0 (iPad; CPU OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1",
+   "count":1
+}
 ~~~

--- a/_posts/2019-02-14-dev.md
+++ b/_posts/2019-02-14-dev.md
@@ -6,111 +6,52 @@ date: 2019-02-14 17:34:41
 ---
 
 
-This document describes how to setup a development environment for BigBlueButton 2.2 (or later).  Once setup, you can modify the client and server components.
+Welcome to the BigBlueButton Developer's Guide for BigBlueButton 2.2.
 
-The BigBlueButton client is a single page, responsive web application that is built upon the following components: 
-  * [React.js](https://facebook.github.io/react/) for rendering the user interface in an efficient manner
-  * [WebRTC](https://webrtc.org/) for sending/receiving audio and video
-
-The BigBlueButton server is built upon
-  * [Meteor.js](http://meteor.com) in [ECMA2015](http://www.ecma-international.org/ecma-262/6.0/)
-for communication between client and server.
-  * [MongoDB](https://www.mongodb.com/) for keeping the state of each BigBlueButton client consistent with the BigBlueButton server
+This document gives you an overview of how to setup a development environment for BigBlueButton 2.2-beta (referred hereafter as BigBlueButton 2.2).
 
 
-The instructions in this guide are step-by-step so you can edit the source, test your changes, and commit any changes to your fork of BigBlueButton..  If you encounter errors when following these steps, stop and double-check that you have done the step correctly.  If you are unable to determine the cause of the error, do the following
+# Before you begin
 
-  * Use Google to search for the error.  There is a wealth of information in [bigbluebutton-dev](https://groups.google.com/forum/?fromgroups=#!forum/bigbluebutton-dev) that has been indexed by Google.
-  * Redo the same steps on a different BigBlueButton server.
-  * Post the issue to bigbluebutton-dev with a description of the problem and the steps to reproduce. Post any relevant logs and error messages to [Pastebin](http://pastebin.com) link them in your post.
+You first need to setup a BigBlueButton 2.2 server.  See the instructions at [Install BigBlueButton 2.2](/2.2/install.html).
 
+# Overview
 
-# Architecture Overivew
+A BigBlueButton server is built from a number of components that correspond to Ubuntu packages.  Some of these components are
 
-When you start up a BigBlueButton session, your browser loads the source code for the client which, when loaded, estabilishes a connection to the BigBlueButton server -- specifically to the MongoDB database on the server.
+  * bbb-web -- Implements the BigBlueButton API and conversion of documents for presentation
+  * akka-bbb-apps -- Server side application that handles the state of meetings on the server
+  * html5-client -- Meteor application leveraging MongoDB and React.js
+  * bbb-client -- Flash based client that loads within the browser
+  * bbb-apps -- Server side application for sending and receiving messages with the Flash client
+  * bbb-screenshare -- Screen sharing server
 
-## Client
+You don't need to understand everything about each component, but you do need to understand the [overall architecture](/overview/architecture.html) and how the components work together.
 
-The MongoDB database contains information about all meetings on the server and, in turn, each client connected to a meeting.
+This document describes how to setup a development environment using an existing BigBlueButton 2.2 server.  Once the environment is setup, you will be able to make custom changes to BigBlueButton source, compile the source, and replace the corresponding components on the server (such as updating the BigBlueButton client).
 
-Each user's client is only aware of the their meeting's state, such the user's public and private chat messages sent and received.
+The instructions in this guide are step-by-step so you can understand each step needed to modify a component.  If you encounter problems or errors at any section, don't ignore the errors.  Stop and double-check that you have done the step correctly.  If you are unable to determine the cause of the error, do the following
 
-The following diagram gives an overview of the architecture of the HTML5 client and its communications with the other components in BigBlueButton.
-
-![HTML5 Overview](/images/html5-client-architecture.png)
-
-The client uses the [SASS](http://sass-lang.com/) precompiler to keep the stylesheets short and readable. SASS is a stylesheet language that is compiled into CSS.   
-
-The responsive UI of the HTML5 client is constructed using media queries. Each SASS expression is tied to some specific range of devices and window sizes.
-
-All the code for the HTML5 client is inside the [bigbluebutton/bigbluebutton-html5](https://github.com/bigbluebutton/bigbluebutton/tree/master/bigbluebutton-html5) folder in GitHub.  
-
-
-## Server
-
-MongoDB is initalized by a Meteor application (which application?).
-
-When the Meteor application starts, it connects to redis via a RedisPubSub channel, then sends a JSON request message `get_all_meetings_request` to `bbb-apps`, which triggers the following response:
-
-~~~json
-{
-   "payload": {
-     "meetings": [
-       {
-         "meetingID": "183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1415134791204",
-         "meetingName": "Demo Meeting",
-         "recorded": false,
-         "voiceBridge": "70827",
-         "duration": 0
-       }
-     ]
-   },
-   "header": {
-     "timestamp": 3350491563,
-     "name": "get_all_meetings_reply",
-     "current_time": 1415312516720,
-     "version": "0.0.1"
-   }
-}
-~~~
-
-`bbb-apps` then parses this message and populates the`Meetings` stored in MongoDB.
-
-Next, the application obtains an array of all users, presentations and the chat history for each meeting (from where?).
-Using this information, the application populations the following collections: Users, Chat, Presentations, Shapes, and Slides.
-
-We are subscribed to receive event messages on the following Redis channel:
-
-  * "to-html5-redis-channel"
-  * "from-akka-apps-*"
-
-And we publish event messages on:
-
-  * "to-akka-apps-redis-channel"
-
-Throughout the meeting we keep receiving json messages via Redis about all the events in the meetings on the BigBlueButton server.
-The handling procedure typically involves updating the particular document[s] in the collection.
-
-### Consistency of state
-
-We rely heavily on the fact that MongoDB on the server side automatically pushes updates to MiniMongo on the client side.
-The client side subscribes to the published collections on the server side. During the subscription, the meetingId, userId and authToken of the user logged in the client are required. These 3 identifiers provide enough information for the publishing mechanism to decide what subset of the collections the user logged in the client is authorized to view.
-
-If a user loses connection while in the meeting, a message appears on the screen informing the user about the disconnection and the reconnection countdown. The client will periodically attempt to reconnect. If the reconnection is successful, the client will reappear with everything up to date.
-
+  * First, use Google to search for the error.  There is a wealth of information in [bigbluebutton-dev](https://groups.google.com/forum/?fromgroups=#!forum/bigbluebutton-dev) that has been indexed by Google.
+  * Try doing the same steps on a different BigBlueButton server.
+  * Post a question to bigbluebutton-dev with a description of the problem and the steps to reproduce. Post logs and error messages to [Pastebin](http://pastebin.com) link them in your post.
 
 
 ## Before you begin
 
 This section makes sure you are ready to setup a BigBlueButton development environment.
 
-### Setup a working BigBlueButton server
+### You Have a Working BigBlueButton Server
 
-Before you can start developing on BigBlueButton, you need to have a working BigBlueButton server (see [install BigBlueButton 2.2](/2.2/install.html)).   The BigBlueButton server already has the HTML5 client and necessary packages to run the client.  By starting with a working server, you can customize just the components you want to change.
-For debugging, you also have the ability to switch back-and-forth between the default-packaged components and any modifications you make.
+Before you can start developing on BigBlueButton, you must install BigBlueButton 2.2 (see [installation steps](/2.2/install.html)) and ensure it's working correctly. Make sure there were no errors during the installation and that you can join a session successfully.
+
+We emphasize that your BigBlueButton server must be working **before** you start setting up the development environment.  Be sure that you can login, start sessions, join the audio bridge, share your webcam, and record and playback sessions -- all using the built-in API demos.
+
+By starting with a working BigBlueButton server, you have the ability to switch back-and-forth between the default-packaged components and any modifications you make.
 
 For example, suppose you modify the BigBlueButton client and something isn't working (such as the client is not fully loading), you can easily switch back to the default-packaged client and check that it's working correctly (thus ruling out any environment issues that may also be preventing your modified client from loading).
 
+**Another Note:** These instructions assume you have the `bbb-demo` package installed so you can run any of the API demos to test your setup.
 
 ### Developing on Windows
 
@@ -120,7 +61,11 @@ When setting up the VM, it does not matter to BigBlueButton if you setup Ubuntu 
 
 ### Root Privileges
 
-**Important:**  Do not run commands as the root user and only use `sudo` command when indicated by instructions. Instead, run the commands in a user (non-root) account.  The documention is written using the account `firstuser`, but you can use any user account.
+**Important:** Make sure you create another user such as "ubuntu" to avoid running into permission errors such as Nginx 403 Forbidden error or [error-null-while-compiling-resource-bundles-under-linux-with-hudson](http://stackoverflow.com/questions/3863066/error-null-while-compiling-resource-bundles-under-linux-with-hudson).
+
+Do not run commands as the root user and only use sudo when instructed to.
+
+These instructions are written for an account called "ubuntu", but they will apply to any account that has the permissions to execute commands as root, such as
 
 ~~~
 sudo ls
@@ -142,7 +87,7 @@ The BigBlueButton [source is hosted on GitHub](https://github.com/bigbluebutton/
   * create a branch
   * push changes back to a repository
 
-If you have not used git before, or if the terms **_clone_**, **_branch_**, and **_commit_** are unfamiliar to you, stop now.  These are fundamental concepts to git that you need to become competent with before trying to develop on BigBlueButton. To become competent, a good place to start is this [free book](http://progit.org/book/) and [GitHub Help pages](http://help.github.com/).
+If you have not used git before, or if the terms **_clone_**, **_branch_**, and **_commit_** are unfamiliar to you, stop now.  These are fundamental concepts to git that you need to become competent with before trying to develop on BigBlueButton. To become competent, a good place to start is this [free book](http://git-scm.com/book) and [GitHub Help pages](http://help.github.com/).
 
 Using GitHub makes it easy for you to work on your own copy of the BigBlueButton source, store your updates to the source to your GitHub account, and make it easy for you to [contribute to BigBlueButton](/support/faq.html#contributing-to-bigbluebutton).
 
@@ -151,14 +96,12 @@ Using GitHub makes it easy for you to work on your own copy of the BigBlueButton
 We recommend you subscribe to the [bigbluebutton-dev](http://groups.google.com/group/bigbluebutton-dev/topics?gvc=2) mailing list to follow updates to the development of BigBlueButton and to collaborate with other developers.
 
 
-## Overivew of Architecture
-
 # Setup a Development Environment
 
 First, you need to install the core development tools.
 
 ~~~
-sudo apt-get install git-core ant openjdk-8-jdk-headless
+sudo apt-get install git-core ant ant-contrib openjdk-8-jdk-headless
 ~~~
 
 With the JDK installed, you need to set the JAVA_HOME variable. Edit `~/.profile` (here we are using vim to edit the file)
@@ -186,128 +129,136 @@ $ echo $JAVA_HOME
 /usr/lib/jvm/java-8-openjdk-amd64
 ~~~
 
-In the next step, you need to install a number of tools using `sdkman`.
+In the next step, you need to install a number of tools using sdkman.
 
 ~~~
 curl -s "https://get.sdkman.io" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 
-sdk install gradle 5.1.1
-sdk install grails 3.3.9
-sdk install sbt 1.2.6
-sdk install maven 3.3.9
+sdk install gradle 2.12
+sdk install grails 2.5.2
+sdk install sbt 0.13.9
+sdk install maven 3.5.0
 ~~~
 
-You will need to download some files throughout these instructions using curl. If it is not installed on your server, you can install the package using the following command
+## Legacy Tools
 
-~~~
-$ sudo apt-get install curl
-~~~
-
-You will need to install [Meteor.js](http://www.meteor.com).
-
-~~~
-$ curl https://install.meteor.com/ | sh
-~~~
-
-Got the tools setup?  Great, now let's checkout the source.
+Instructions for downloading the Flash SDK can be found [here](/2.2-legacy-dev/).
 
 ## Checking out the Source
 
-Let's create a directory to hold the source code.
+With the development tools installed, we'll next clone the source in the following directory:
 
 ~~~
-mkdir ~/dev
-cd ~/dev
+/home/ubuntu/dev
 ~~~
 
+Using your GitHub account, do the following
 
-Next, using your GitHub account, do the following
-
-1. [Fork](http://help.github.com/fork-a-repo/) the BigBlueButton repository into your GitHub account.
-2. Clone your repository into your `~/dev` folder.
-
-The work on the HTML5 client is occuring in the `master` branch.
-
-~~~
-$ git clone https://github.com/<YOUR_GITHUB_USERNAME>/bigbluebutton.git
-$ cd bigbluebutton
-~~~
+1. [Fork](http://help.github.com/fork-a-repo/) the BigBlueButton repository into your GitHub account
+2. Clone your repository into your `~/dev` folder
 
 After cloning, you'll have the following directory (make sure the `bigbluebutton` directory is within your `dev` directory).
 
-Next, make sure you are on the `master` branch.
-
 ~~~
-git fetch origin
-git checkout master
-
+/home/ubuntu/dev/bigbluebutton
 ~~~
 
-Confirm that you are working on the `master` branch.
+Confirm that you are working on the master branch.
 
 ~~~
-$ git status
-On branch master
-Your branch is up-to-date with 'origin/master'.
-nothing to commit, working directory clean
+cd /home/ubuntu/dev/bigbluebutton
+git status
 ~~~
 
-## Setup of the development environment 
-
-First, shut down the packaged version of the HTML5 client so you are not running two copies in parallel.
+You should see
 
 ~~~
-$ sudo systemctl stop bbb-html5
+# On branch master
+nothing to commit (working directory clean)
 ~~~
 
-output from the above command contains errors check again the nginx configuration you just edited.
+When you first clone the BigBlueButton git repository, git will place you, by default, on the `master` branch, which is the latest code for BigBlueButton.  At this point the `master` branch is fine for BBB 2.2 development, but in the future there will be a release branch for 2.2 likely named `v2.2.x-release`.
+
+The first thing we need to do is to add the remote repository to our local clone.
+
+~~~
+git remote add upstream https://github.com/bigbluebutton/bigbluebutton.git
+~~~
+
+You can now check your local list of tracked repositories to verify that the addition worked. You should see at least two results (origin and upstream). The one named "origin" should link to your personal fork and is the repository that you cloned. The second result "upstream" should link to the main BigBlueButton repository.
+
+~~~
+git remote -v
+~~~
+
+After, we need to fetch the most up to date version of the remote repository.
+
+~~~
+git fetch upstream
+~~~
+
+You are now ready to create a new branch to start your work and base the new branch off master.
+
+~~~
+git checkout -b my-changes-branch upstream/master
+~~~
+
+"checkout" switches branches
+
+"-b" is an option to create a new branch before switching
+
+"my-changes-branch" will be the name of the new branch
+
+"upstream/master" is where you want to start your new branch
+
+You should now confirm that you are in the correct branch.
+
+~~~
+git status
+
+# On branch my-changes-branch
+nothing to commit (working directory clean)
+~~~
+
+# Production Environment
+
+Okay. Let's pause for a minute. 
+
+You have set-up the necessary tools and cloned the source, but if you are going to start making changes to BigBlueButton code you need to understand how the parts interact. 
+
+Below is an overview of the different components in a production set-up. When developing you want to change your configuration settings to load new changes instead of the ones deployed for production.
+
+![production](/images/10/prod-env.png)
+
+As you can see, nginx is configured to load the client from `/var/www/bigbluebutton/client` directory and forward calls to web-api on tomcat7. During development, you need to tell nginx to load from your development directory (`/home/ubuntu/dev/bigbluebutton`)
+
+After going through the steps below, you will end up with the following setup.
+
+![development](/images/10/dev-env.png)
+
+The components that run in Red5 don't change when you deploy the development files for bbb-apps, bbb-voice, bbb-video, and bbb-deskshare into `/usr/share/red5`. However, notice that the client and web-api are served from  different places.
 
 
-### Running the HTML5 client
+# Developing the HTML5 client
 
 ~~~
 $ cd ~/dev/bigbluebutton/bigbluebutton-html5
 ~~~  
 
-Install the npm dependencies (your output may differ)
+Next, shut down the packaged version of the HTML5 client so you are not running two copies in parallel.
+
+~~~
+$ sudo systemctl stop bbb-html5
+~~~
+
+Install the npm dependencies
 
 ~~~
 $ meteor npm install
-
-> fibers@3.1.1 install /home/ubuntu/dev/bigbluebutton/bigbluebutton-html5/node_modules/fibers
-> node build.js || nodejs build.js
-
-`linux-x64-57-glibc` exists; testing
-Binary is fine; exiting
-
-> husky@1.3.1 install /home/ubuntu/dev/bigbluebutton/bigbluebutton-html5/node_modules/husky
-> node husky install
-
-husky > setting up git hooks
-husky > done
-
-> node-sass@4.11.0 install /home/ubuntu/dev/bigbluebutton/bigbluebutton-html5/node_modules/node-sass
-> node scripts/install.js
-
-Downloading binary from https://github.com/sass/node-sass/releases/download/v4.11.0/linux-x64-57_binding.node
-Download complete..] - :
-Binary saved to /home/ubuntu/dev/bigbluebutton/bigbluebutton-html5/node_modules/node-sass/vendor/linux-x64-57/binding.node
-Caching binary to /home/ubuntu/.npm/node-sass/4.11.0/linux-x64-57_binding.node
-
-> node-sass@4.11.0 postinstall /home/ubuntu/dev/bigbluebutton/bigbluebutton-html5/node_modules/node-sass
-> node scripts/build.js
-
-Binary found at /home/ubuntu/dev/bigbluebutton/bigbluebutton-html5/node_modules/node-sass/vendor/linux-x64-57/binding.node
-Testing binary
-Binary is fine
-npm WARN bbb-html5-client@ No license field.
-
-added 903 packages from 583 contributors and audited 3951 packages in 17.784s
-found 0 vulnerabilities
 ~~~
 
-In order to run the server side of the HTML5 client you will need to execute the following:
+Run the HTML5 code
 
 ~~~
 $ npm start
@@ -319,641 +270,237 @@ By default, the client will run in `development` mode. Loading into production e
 $ NODE_ENV=production npm start
 ~~~
 
-Wait until the process starts and confirm that the configuration is valid by navigating to
+## HTML5 Coding Practices
 
-~~~
-http://<your_ip>/html5client/check
-~~~
+For coding conventions related to the HTML5 code refer to [this document](/html5-best-practices.html).
 
-The result should be `{"html5clientStatus":"running"}`.
+## /private/config
 
-### Usage
-
-There are several ways to join a meeting using the HTML5 client:
-
-#### Attempt joining on a device which does not have Flash
-If you visit a link (to a BigBlueButton meeting) on your Android/iOS device you will automatically be using the HTML5 client. The same goes for opening the link with a desktop browser if Flash has been disabled.
-
-#### Starting from a demo page
-Make sure you have the demos package installed: `sudo apt install bbb-demos`.  Go to `http://<your_ip>/` in the browser. Select "API examples". Navigate to “HTML5 Client Demo” and use the form. You will enter a meeting titled "Demo Meeting".
-
-#### Pass parameter on joining 
-Pass `joinViaHtml5=true` as a parameter and you will be navigating into the meeting using the HTML5 client.
-
-#### Configure the server to prefer HTML5 for some/all users
-You can modify `bigbluebutton.properties` so that all attendees or all moderators (or everyone) joins via HTML5. For this set `attendeesJoinViaHTML5Client` or `moderatorsJoinViaHTML5Client` to true and restart BigBlueButton.
-
-### Serve the client over HTTPS
-Make sure you follow the instructions for [configuring SSL on BigBlueButton](/2.2/install.html#configure-ssl-on-your-bigbluebutton-server). Test your server using the Flash client. Make sure the audio works and the slides display properly.
-The HTML5 client does not require any additional configuration to run over https. If the rest of BigBlueButton is running fine as https, you are set!
-
-# Localization with Transifex
-
-We use Transifex for crowdsourcing for BigBlueButton Internationalization(i18n). The following steps are not a part of the typical installation and are only required for bringing the language strings in github up to date. There are two ways to pull the translation files; using the transifex.sh script or the transifex client.
-
-## Using transifex.sh
-
-The transifex.sh script aims to make retrieving translation files on the Transifex servers as simple as possible. In order to use the script, you must provide your Transifex credentials which have the appropriate authorization. The script can be used in the following ways.
-
-~~~
-$ ./transifex.sh all
-~~~
-
-Using the all argument will tell the script to download all available translation files.
-
-~~~
-$ ./transifex.sh fr de pt-BR
-~~~
-
-If you only need a specific set of translations, the script can be run with the required locales as argument.
-
-
-## Setup & Configure Transifex Client
-
-This is an alternative method to using the transifex.sh and is essentially the manual process for retrieving translation files from the Transifex servers.
-
-### 1. Install Transifex Client ###
-
-To installation the Transifex client we use pip, a package management system designed to manage and install Python packages.
-
-~~~
-$ sudo apt-get install python-pip
-~~~
-
-Next we use Pip to install the Transifex client.
-
-~~~
-$ sudo pip install transifex-client
-~~~
-
-The following command is used to upgrade the client to the most current version.
-
-~~~
-$ pip install --upgrade transifex-client
-~~~
-
-### 2. Transifex Project Initialization ###
-
-The `tx init` command is used to initialize a project. Run from the root directory of the application.
-
-~~~
-$ tx init
-Creating .tx folder. . .
-Transifex instance [https://www.transifex.com]:
-~~~
-
-Press Enter (will be prompted for your Transifex username and password)
-
-~~~
-Creating skeleton...
-Creating config file...
-​Done.
-~~~
-
-This will create a Transifex project file in the current directory containing the project’s configuration file.
-
-
-### 3. Transifex Client configuration ###
-#### .tx/config ####
-
-The Transifex client uses a per project configuration file. This is located in .tx/config of your project's root directory and is generated on running the `tx init` command. It should be updated with the following configuration:
-
-~~~
-[main]
-host = https://www.transifex.com
-
-[bigbluebutton-html5.enjson]
-file_filter = private/locales/<lang>.json
-source_file = private/locales/en_US.json
-source_lang = en_US
-type = KEYVALUEJSON
-~~~
-
-
-### 4. Set a Project Remote ###
-
-`tx set` allows you to configure and edit Transifex project files on your local computer.
-
-The following command is used to initialize a local project for the remote project specified by the URL.
-
-`$ tx set --auto-remote https://www.transifex.com/projects/p/bigbluebutton-html5/resources/enjson/`
-
-Next we can pull language files located on the Transifex server.
-
-
-### 5. Pull: Download Transifex Translations ###
-
-To pull all translation files from the Transifex server, the following command is used.
-
-`$ tx pull -a bigbluebutton-html5.enjson`
-
-In the event that there are a lot of translations, instead of pulling all, we can specify which translations we want to acquire.
-
-`$ tx pull -r bigbluebutton-html5.enjson -l pt_BR`
-
-Alternatively, simply download a ZIP archive of all languages in the project from the Transifex project page and unarchive it in the `private/locales/` directory.
-
-# Accessibility
-
-We developed the BigBlueButton HTML5 client with the goal of having the best accessibility support for a web conferencing system.
-
-In order to accommodate all of the users who may have one or a combination of impairments, we refer to the Web Content Accessibility Guidelines (WCAG) 2.0. This document outlines the standards expected to be included, where applicable, with all HTML markup on the web.
-
-When dealing with web accessibility there are a few key factors we must keep in mind while developing
-
-  1. Tab Order
-  2. Color Contrast
-  3. Focus
-  4. Semantics
-  5. Testing
-
-## Tab Order
-
-The goal when implementing the tab order is ensuring the elements in the  tab sequence are logical and simple.
-
-When a user presses the tab key focus should move to the next interactable element. If the user continues to press the tab key, focus should move in a logical order through all the interactable elements on the page. The tab focus should be visually identified, currently the HTML5 client adds a thin border to the field, when tab is pressed focus is seen to visibly move.
-
-***Note: A number of users including the following.***
-
-  * ***Those with visual impairments, who rely on screen readers or screen magnifiers.***
-  * ***Those with limited dexterity, who depend on the use of the keyboard to using a mouse.***
-  * ***Those who can only utilize a single switch to control a computer.***
-
-***will all navigate through a page by using the tab button.***
-
-
-The order of elements in the DOM determine their place in the tab order, for elements that should receive focus. Elements that don’t natively receive focus can be inserted into the tab order by adding a tabindex=”0” property.
-
-***Caution:***
-***When using the tabindex property, positive values should generally be avoided because it places elements outside of the natural tab order, this can present issues for screen reader users who rely on navigating the DOM through a linear manner.***
-
-The following extension gives a visual representation of the tab order of a current web document.
-
-### ChromeLens
-offered by ngzhian
-
-![Contrast Ratio Calculator](/images/accessibility_chromelense.jpg)
-https://chrome.google.com/webstore/detail/chromelens/idikgljglpfilbhaboonnpnnincjhjkd?hl=en
-
-
-## Focus
-
-
-## Color Contrast
-
-When dealing with color contrast we are talking about finding colors for a scheme that not only implement maximum contrast, but gives the appropriate contrast between the content and its background for those who experience low visual impairments, color deficiencies or the loss of contrast typically accompanied by aging.
-
-The HTML5 client ensures that all visual designs meet the minimum color-contrast ratio for both normal as well as large text on a background, described by the WCAG 2.0 AA standards.  “Contrast (Minimum): Understanding Success Criterion 1.4.3.” 
-
-To make sure that we have met these guidelines, there are numerous tools available online which allow the comparison of foreground and background colors using hex values, to see if they fall within the appropriate contrast ratio.
-
-![Contrast Ratio Calculator](/images/accessibility_colorchecker.jpg)
-http://webaim.org/resources/contrastchecker/
-
-
-### Currently implemented colors:
-
-![Currently implemented element colors](/images/accessibility_colors1.jpg)
-![Currently implemented typography colors](/images/accessibility_colors2.jpg)
- 
-* Blue - primary color - action buttons
-* Red - closing audio, indicators and error alerts
-* Green - audio indicator, success alert, check marks
-* Orange - warning alerts
-* Dark Blue - Headings
-* Grey - base typography color
-
-
-***Note:***
-***The ChromeLense extension also provides the ability to view your browser using different personas of users who may view web content with various different visual impairments. This is particularly useful when deciding on appropriate color schemes to best suit a wider range of users.***
-
-
-## Semantics
-
-Users with visual disabilities can miss out on visual affordances. We need to make sure the information we are trying to express, is expressed in a way that flexible enough so assistive technology can pick up on it; creating an alternative interface for our users. we refer to this as expressing the semantics of an element.
-
-The HTML5 client uses the WAI-ARIA (Web Accessibility Initiative – Accessible Rich Internet Applications) to provide access to screen readers. The following list of commonly used aria attributes:
-
-  * aria-role
-  * aria-label
-  * aria-labelledby
-  * aria-describedby
-  * aria-hidden
-  * aria-live
-  * aria-expanded
-  * aria-haspopup
-
- #### Links
-  
-  HTML5 ARIA spec - http://www.w3.org/TR/aria-in-html/
-
-  ARIA spec - http://www.w3.org/WAI/PF/aria/
-  
-  Roles - http://www.w3.org/TR/wai-aria/roles
-  
-  States and Properties - http://www.w3.org/TR/wai-aria/states_and_properties
-  
-  Design Patterns - http://www.w3.org/TR/wai-aria-practices/#aria_ex
-
-
-### Testing
-
-Testing for accessibility can be a somewhat painful process, if you try to manually find and fix all the issues. While it is good practice to go through a checklist and ensure all elements in the HTML5 client meet their accessibility requirements, this process can be very slow and time consuming. For this reason it is suggested to use an automated accessibility auditor first.
-
-#### aXe
-offered by Deque Systems
-
-![aXe](/images/accessibility_axe.jpg)
-https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd
-
-#### Accessibility Developer Tools
-offered by Google Accessibility
-
-![Accessibility Developer Tools](/images/accessibility_audit.jpg)
-https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb
-
-Both of these extensions provide the ability to scan the DOM and report on any accessibility issues based on levels which can be set, weather AA or AAA standards. For the purposes of the HTML5 client we follow the AA guidelines. Any reported errors also come with a listing of potential fixes.
-
-***Note:***
-***Once these extensions are installed to the browser they must be run from inside the console.***
-
-
-## Training
-
-We recommenbd checking out this [free online accessibility course](http://www.udacity.com/course/web-accessibility--ud891) which can provide a very good understanding of the basics of dealing with web accessibility for both developers and designers. 
-
-In the event you do not need to take the course but would still like access to the information as reference, the course is also found in [full document form](https://developers.google.com/web/fundamentals/accessibility) . It is a live document which is updated by the developers over at Google.
-
-
-# Coding Practices
-
-When making a new component there is a certain structure to implement and existing components to utilize to make your life easier.
-
-## Buttons
-
-
-There is a standard button component we use in the client. It is located inside of <b>/imports/ui/shared/Button.jsx</b>. It should be used for every button.
-
-## Font Size
-
-
-Inside of <b>/client/stylesheets</b> there is a stylesheet <b>fontSizing.css</b>.
-
-It will contain style classes such as extraSmallFont, smallFont, mediumFont, etc. Every piece of html with text to display to the client should be assigned one of these classes. This will allow text to scale responsively and still maintain relative size. You can set the class of an element to one of these classes, and have everything inside the container element inherit the font size rather than assign it to each individual child to save some work.
-
-# Localization
-
-
-The HTML5 client supports localizations by using the React-Intl  which allows the HTML5 client to have fully localized messages which are uploaded to Transifex for translating. As a result of this we have added the ability within the HTML5 client to switch the language of the application.
-
-The main language file is `en.json`. When there is a new field to localize, we update `en.json`, and then the new field string becomes available for crowdsourced translation on [Transifex](https://www.transifex.com)
-
-When declaring formatted messages we use  defineMessages and  injectIntl in place of FormattedMessage.
-
-~~~
-Import { injectIntl } from ‘react-intl’;          //pass’s messages as prop to the component
-import { defineMessages } from 'react-intl';      //import so we can group together all messages inside a component.
-
-const intlMessages = defineMessages({             //all messages can be defined in intlMessages
-  title: {
-	id: 'app.about.title', 	                        //id corresponds to the id in the locale file
-	description: 'About title label in Settings menu', //gives developers additional context about the element/item
-  },
-});
-~~~
-
-We omit the default message prop because it is the same as the string located in the locale file. By doing this we keep context of what the id’s mean while eliminating duplication.  Once the messages are defined we then add the following to use the `injectIntl`:
-
-~~~
-export default injectIntl(ComponentName);
-~~~
-
-From this point we can use the messages directly as they are passed down as props.
-
-~~~
-const { intl } = this.props;     //defined messages get passed as props
-
-<Button
-    role="button"
-    label={intl.formatMessage(intlMessages.title)}   	  //gets rendered to the screen
-    aria-label={intl.formatMessage(intlMessages.title)}    //voiced by screen reader
-/>
-~~~
-
-If the browser is requesting a locale file that does not contain all the translations, all the available strings will be merged with the locale file set as the default. In this case all messages will be displayed but may have a mixture of languages.
-
-If message id’s are missing from the locale file set as the default, and the browser requests the default or another locale containing a portion of the translated strings; there is potential for the missing id’s to not render a message and in this care default to the id of the message. To ensure this does not occur we make sure that the locale specified as the default always contains 100% of the used messages.
-
-## Server Calls
-
-
-To make a call to the server from the client, you should refer to the <b>callServer</b> function in <b>/imports/ui/services/api/index.js</b>.
-
-Always use this in favor of <b>Meteor.call</b>. The <b>callServer</b> function should operate the same way in that you pass the name of the method to call as a string, and then the arguments just like normal.
-
-[Meteor.call()](http://docs.meteor.com/#/full/meteor_call)
-
-
-# Project Structure
-
-<style type="text/css">
-pre
-{
-white-space: pre;
-overflow-x: auto;
-font-size: 0.85em;
-font-family: Monaco,Menlo,Consolas,"Courier New",monospace;
-}
-
-.comments{
-color: #A9A9A9;
-}
-</style>
-
-This section covers the structure for the HTML5 project
-
-## Meteor Structure
-
-<pre>
-imports/               
-  startup/                
-    client/               
-      index.js                      <span class="comments"># import client startup through a single index entity</span>
-      routes.js                     <span class="comments"># set up all routes in the app</span>
-      useraccounts-configuration.js <span class="comments"># configure login templates</span>
-    server/  
-      fixtures.js                   <span class="comments"># fill the DB with example data on startup</span>
-      index.js                      <span class="comments"># import server startup through a single index entity</span>
-
-  api/
-    lists/                          <span class="comments"># a unit of domain logic</span>
-      server/  
-        publications.js             <span class="comments"># all list-related publications</span>
-        publications.test.js        <span class="comments"># tests for the lists publications</span>
-      lists.js                      <span class="comments"># definition of the Lists collection</span>
-      lists.tests.js                <span class="comments"># tests for the behavior of that collection</span>
-      methods.js                    <span class="comments"># methods related to lists</span>
-      methods.tests.js              <span class="comments"># tests for those methods</span>
-
-  ui/  
-    components/                     <span class="comments"># all reusable components in the application</span>
-                                    <span class="comments"># can be split by domain if there are many</span>
-    layouts/                        <span class="comments"># wrapper components for behavior and visuals</span>
-    pages/                          <span class="comments"># entry points for rendering used by the router</span>
-
-client/  
-  main.js                           <span class="comments"># client entry point, import all client code</span>
-
-server/
-  main.js                           <span class="comments"># server entry point, import all server code</span>
-</pre>
-
-Taken from [Meteor Structure](http://guide.meteor.com/structure.html#example-app-structure)
-
-Inside imports is where we store all units of functionality for the HTML5 client.
-
-Inside API is where we store the collection data that we use, sort of like a model.
-
-Inside UI is where we store what would be the view for the models.
-
-
-## API
-
-
-Located under <b>/imports/api</b>
-
-Each sub-directory here will either be a data collection, or some service we use in the client.
-
-The name of the subdirectory should be in lower-case representing the name of the Mongo collection, or following typical programming collection it will be PascalCased representing a class name.
-
-Differing from the Meteor Structure is that for security purposes we want the majority of our functionality in the <b>/server</b> directory, which keeps it from loading on the clients.
-
-The main export or class for the API component should be in <b>index.js</b>, which allows for easy importing. So to import the Polling collection for example, we can use the following code `import Polls from 'imports/api/polls/'`.
-
-Since it is <b>index.js</b> we don’t have to specify that file since it is default.
-
-Naming files this way can conflict with certain conventions where the file name is named after the main class inside it. To go about this we simply have a default export for the collections, and in the case of a collection we export the new instance.
-
-Inside the <b>/server</b> directory of every API component we have a named file named publications.js. This is where we put the Meteor publish callback for the collection.
-
-We now have 2 more sub-directories inside the <b>/server</b> directory-- methods and modifiers.
-
-### /methods
-
-Inside <b>/methods</b> we have one file per method. These methods are where we declare the Meteor.Methods for the collection-- which are Meteor server methods that can be invoked from the Meteor client. We have one file per method, and they are named in camelCase. They shouldn’t need an export because of how they are registered in Meteor. They will however have to be imported on the server (at startup) to execute the code.
-
-### /modifiers
-
-Inside <b>/modifiers</b> we have one file per method. These functions that go in here include the functions that modify the <b>collection/data/class</b>, from the server side. We have one file per method, and they are named in camelCase. There should be one export per file. And these will be imported wherever needed. These are almost all functions that will be called from Redis message listeners.
-
-### eventHandlers.js
-
-Inside `imports/api/<collection>/server/` we have a file called `eventHandlers.js`. This file will contain all the event handlers for the collection.
-
-/ui
----
-
-Inside /ui we will have sub-directories for
-
--   components
-
--   services
-
--   stylesheets
-
-### /services
-
-will have <b>/api/index.js</b>. Which is where we will store client-side-wide services and helpers. The functions and data in here will all be exported on the last line of the file in one export statement. This allows someone to just look at the last line of the file and easily see what the file exports.
-
-### /components
-
-Inside this directory each sub-directory will represent a React Component. The name of the sub-directory is what the name of the component is. They are all lowercase, with dashes (-) between words. The standard file are
-
--   component.jsx
-
--   container.jsx
-
--   service.js
-
--   styles.scss
-
-Example
-
--&gt; /whiteboard
-
-&emsp; &emsp;-&gt; component.jsx
-
-&emsp; &emsp;-&gt; service.js
-
-&emsp; &emsp;-&gt; container.js
-
-&emsp; &emsp;-&gt; /slide/component.jsx
-
-&emsp; &emsp;-&gt; /cursor/component.jsx
-
-&emsp; &emsp;-&gt; /shape-factory/component.jsx
-
-&emsp; &emsp;-&gt; /shapes
-
-&emsp; &emsp; &emsp; &emsp;-&gt; /ellipse/component.jsx
-
-&emsp; &emsp; &emsp; &emsp;-&gt; /triangle/component.jsx
-
-&emsp; &emsp; &emsp; &emsp;-&gt; ... &lt;the rest of the shape components&gt;
-
-#### Component
-
-All components will be React ES6 style classes (not React Classes). A component should only need to have one export and it should be the default export. Refer to the official React documentation on how to structure a component class. The component file will be named <b>component.jsx</b>.
-
-#### Container
-
-[createContainer()](http://guide.meteor.com/react.html#using-createContainer)
-
-A container is a React ES6 class that will pass data to the component. The container will also be in control of whether or not the component should render. A container should retrieve data from the service and pass it into the container class.
-
-The container file will be named <b>container.jsx</b>. The file should have only one export and should be the default export. The export should be the result of the `createContainer()` function.
-
-#### Service
-
-The service file should be named <b>service.js</b>.
-
-The file can export as many function, objects, or other pieces of data as it needs. The service can interface with other collections as well. There should only be one export statement in the file. The last line of the file should export all the functions and pieces of data in an object. Restrain from wrapping everything inside a function and exporting the function wrapper.
-
-#### Styles.scss
-
-All styles should be written in SASS when possible.
-
-### /private/config
-
-All configuration files are located in **/private/config**. The file used depends on how you are running the client. In development mode (see `npm start` above) the configuration from `settings-development.json` is picked up. When running the packaged `bbb-html5` service or when passing NODE_ENV=production, the file `settings-production.json` is utilized. If you make any changes to the json configuration you will need to restart the html5 client.
+All configurations are located in **/private/config/settings.yml**. If you make any changes to the YAML configuration you will need to restart the meteor process.
 
 During Meteor.startup() the configuration file is loaded and can be accessed through the Meteor.settings.public object.
 
+# Build bbb-common-message
 
-# Client Logger
-
-To assist with monitoring and debugging, the HTML5 client can send its logs to the BigBlueButton server via the `logger` function.  Here's an example of its use:
-
-~~~  
-import logger from '/imports/startup/client/logger'; 
-
-logger.warn('Hi on warn') 
-~~~ 
-
-The client logger accepts three targets for the logs: `console`, `server` and `external`.
-
-
-Name | Default Value |Accepted Values| Description 
- --- | --- | ---| ---
-target | "console" | "console", "external", "server" | Where the logs will be sent to.
-level | "info"  | "debug", "info", "warn", "error" | The lowest log level that will be sent. Any log level higher than this will also be sent to the target. 
-url | - | - | The end point where logs will be sent to when the target is set to "external".
-method | - | "POST", "PUT" | HTTP method being used when using the target "external".
-
-There are default values in the HTML5 configuration file `/usr/share/meteor/bundle/programs/server/assets/app/config/settings-production.json` (`bigbluebutton/bigbluebutton-html5/private/config/settings-development.json` if you are running the client from source code 
+The bbb-common-message is required by a few components of BigBlueButton. So it is required to build this
+first. Otherwise, you will run into compile errors.
 
 ~~~
-    "clientLog": {
-      "server": { "enabled": true, "level": "info" },
-      "console": { "enabled": false, "level": "debug" },
-      "external": { "enabled": false, "level": "info", "url": "https://<YOUR_DOMAIN>/html5Log", "method": "POST" }
-    }
+cd ~/dev/bigbluebutton/bbb-common-message
+./deploy.sh
 ~~~
 
-Notice that the `external` option is disabled by default - you can enable it on your own server after a few configuration changes.
+# Developing BBB-Web
 
-When setting the output to `external`, the BigBlueButton client will POST the log events to the URL endpoint provided by `url`. To create an associated endpoint on the BigBlueButton server for the POST request, create a file `/etc/bigbluebutton/nginx/client-log.nginx` with the following contents:
+First, we need to update the latest bigbluebutton.properties file according to your setup. Basically, you will have to change the URL and security salt. If you don't know your salt, run `sudo bbb-conf --salt`
 
 ~~~
-location /html5Log {
-	access_log /var/log/nginx/html5-client.log postdata;
-	echo_read_request_body;
+cd ~/dev/bigbluebutton/
+
+# Edit the file and change the values of bigbluebutton.web.serverURL and securitySalt. 
+vi bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+~~~
+
+Now you need to give your user account access to upload slides to the presentation directory and also access to write log files.
+
+~~~
+sudo chmod -R ugo+rwx /var/bigbluebutton
+sudo chmod -R ugo+rwx /var/log/bigbluebutton
+~~~
+
+Now you need to create the nginx file that will redirect calls to your development bbb-web.
+
+~~~
+echo "
+# Handle request to bbb-web running within Tomcat. This is for
+# the BBB-API and Presentation.
+location /bigbluebutton {
+	proxy_pass http://127.0.0.1:8989;
+	proxy_redirect default;
+	proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+
+	# Allow 30M uploaded presentation document.
+	client_max_body_size 30m;
+	client_body_buffer_size 128k;
+
+	proxy_connect_timeout 90;
+	proxy_send_timeout 90;
+	proxy_read_timeout 90;
+
+	proxy_buffer_size 4k;
+	proxy_buffers 4 32k;
+	proxy_busy_buffers_size 64k;
+	proxy_temp_file_write_size 64k;
+
+	include fastcgi_params;
 }
+" | sudo tee /etc/bigbluebutton/nginx/web_dev > /dev/null 2>&1
 ~~~
 
-Then create a file in `/etc/nginx/conf.d/client-log.conf` with the following contents:
+Now we just need to create a link to make sure that the requests are redirected properly then restart nginx.
 
 ~~~
-log_format postdata '$remote_addr [$time_iso8601] $request_body';
+sudo ln -s -f /etc/bigbluebutton/nginx/web_dev /etc/bigbluebutton/nginx/web.nginx
+sudo /etc/init.d/nginx restart
 ~~~
 
-Next, install the full version of nginx.
+Open the file `~/.sbt/0.13/global.sbt` using your editor
 
 ~~~
-sudo apt-get install nginx-full
+mkdir -p ~/.sbt/0.13
+vi ~/.sbt/0.13/global.sbt
 ~~~
 
-You may also need to create the external output file and give it the appropriate permissions and ownership:
-
+Add the following into it
 ~~~
-sudo touch /var/log/nginx/html5-client.log
-sudo chown www-data:adm /var/log/nginx/html5-client.log
-sudo chmod 640 /var/log/nginx/html5-client.log
+resolvers += "Artima Maven Repository" at "http://repo.artima.com/releases"
 ~~~
 
-Restart BigBlueButton with `sudo bbb-conf --restart` and launch the BigBlueButton HTML5 client in a new session.  You should the logs appearing in `/var/log/nginx/html5-client.log` as follows
+Build bbb-common-web
 
 ~~~
-99.239.102.0 [2018-09-09T14:59:10+00:00] [{\x22name: .. }]
+cd ~/dev/bigbluebutton/bbb-common-web
+./deploy.sh
 ~~~
 
-You can follow the logs on the server with the command
+
+Now let's start grails webapp.
 
 ~~~
-tail -f html5-client.log | sed -u -e 's/\\x22/"/g' -e 's/\\x5C/ /g'
+cd ~/dev/bigbluebutton/bigbluebutton-web/
 ~~~
 
-Here's a sample log entry
+Download the necessary libraries.
 
-~~~json
-{  
-   "name":"clientLogger",
-   "level":30,
-   "obj":[  
-      {  
-         "urls":"stun:stun.freeswitch.org"
-      }
-   ],
-   "levelName":"info",
-   "msg":"[audio] iceServers",
-   "time":"2018-08-27T19:32:57.389Z",
-   "src":"https://demo.bigbluebutton.org/html5client/dfe4ad6bfad11b20d1904e76e71d385262781887.js?meteor_js_resource=true:147:782083",
-   "v":1,
-   "clientInfo":{  
-      "sessionToken":"e7boenucj1pwkbfc",
-      "meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1535398242909",
-      "requesterUserId":"w_klfavdlkumj8",
-      "fullname":"Ios",
-      "confname":"Demo Meeting",
-      "externUserID":"w_klfavdlkumj8"
-   },
-   "url":"https://demo.bigbluebutton.org/html5client/users",
-   "userAgent":"Mozilla/5.0 (iPad; CPU OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1",
-   "count":1
-},
-{  
-   "name":"clientLogger",
-   "level":30,
-   "obj":{  
-      "userId":"w_klfavdlkumj8",
-      "userName":"Ios",
-      "topic":"audio"
-   },
-   "levelName":"info",
-   "msg":"[audio] this browser supports websockets",
-   "time":"2018-08-27T19:32:57.393Z",
-   "src":"https://demo.bigbluebutton.org/html5client/dfe4ad6bfad11b20d1904e76e71d385262781887.js?meteor_js_resource=true:147:782083",
-   "v":1,
-   "clientInfo":{  
-      "sessionToken":"e7boenucj1pwkbfc",
-      "meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1535398242909",
-      "requesterUserId":"w_klfavdlkumj8",
-      "fullname":"Ios",
-      "confname":"Demo Meeting",
-      "externUserID":"w_klfavdlkumj8"
-   },
-   "url":"https://demo.bigbluebutton.org/html5client/users",
-   "userAgent":"Mozilla/5.0 (iPad; CPU OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1",
-   "count":1
-}
 ~~~
+./build.sh
+~~~
+
+Start grails and tell to listen on port 8989
+
+~~~
+./run.sh
+~~~
+
+or
+
+~~~
+grails -reloading -Dserver.port=8989 run-app
+~~~
+
+If you get an error `Could not resolve placeholder 'apiVersion'`, just run `grails -Dserver.port=8989 run-war` again. The error is grails not picking up the "bigbluebutton.properties" the first time.
+
+Now test again if you can join the demo meeting.
+
+The command above will run a development version of bbb-web, but if you want to deploy your custom-built bbb-web you need to package a war file.
+
+**TODO: Instructions for deploying 2.2 bbb-web**
+
+If you changed the linking of web.nginx as instructed above you will need to also revert that back to the packaged location for bbb-web.
+
+~~~
+sudo ln -s -f /etc/bigbluebutton/nginx/web /etc/bigbluebutton/nginx/web.nginx
+systemctl restart nginx
+~~~
+
+# Developing Akka-Apps
+
+First you need to stop bbb-apps-akka service.
+
+~~~
+sudo systemctl stop bbb-apps-akka 
+~~~
+
+Then you can manually run the application.
+
+~~~
+cd ~/dev/bigbluebutton/akka-bbb-apps
+sbt clean
+sbt run
+~~~
+
+
+# Developing Akka-FSESL
+
+First, you need to stop bbb-fsesl-akka service.
+
+~~~
+sudo systemctl stop bbb-fsesl-akka
+~~~
+
+You need to build the FS ESL library
+
+~~~
+cd ~/dev/bigbluebutton/bbb-fsesl-client
+sbt publish publishLocal
+~~~
+
+Then you can run the application.
+
+~~~
+cd ~/dev/bigbluebutton/akka-bbb-fsesl
+sbt clean
+sbt run
+~~~
+
+# Legacy Flash applications
+
+For instructions for building the legacy applications related to the Flash client and red5 see [this document](/legacy-dev/).
+
+
+# Troubleshooting
+
+## Welcome to Nginx page
+If you get the "Welcome to Nginx" page. Check if bigbluebutton is enabled in nginx. You should see **bigbluebutton** in `/etc/nginx/sites-enabled`.
+
+If not, enable it.
+
+~~~
+sudo ln -s /etc/nginx/sites-available/bigbluebutton /etc/nginx/sites-enabled/bigbluebutton
+
+sudo /etc/init.d/nginx restart
+~~~
+
+## Pausing/Restarting VM gives wrong date in commit
+If you are developing using a VM and you've paused the VM and later restart it, the time on the VM will be incorrect. The incorrect time will affect any commits you do in GitHub.
+
+To ensure your VM has the correct time, you can install ntp with
+
+~~~
+sudo apt-get install ntp
+sudo /etc/init.d/ntp restart
+~~~
+
+and then do the following after starting the VM from a paused state
+
+~~~
+sudo /etc/init.d/ntp restart
+~~~
+
+The above will re-sync your clock.
+
+# Setup Samba
+
+To setup Samba
+
+~~~
+sudo apt-get install -y --force-yes samba
+~~~
+
+Then setup your shared directory by editing `/etc/samba/smb.conf`
+
+~~~
+; BigBlueButton: Share the development directory
+[ubuntu]
+   comment = BigBlueButton Development share
+   path = /home/ubuntu
+   browseable = yes
+   read only = no
+   create mask = 0755
+   directory mask = 0775
+   guest ok = yes
+   force user = ubuntu
+
+~~~
+
+See [install-samba-server-ubuntu-16-04](https://www.linuxbabe.com/ubuntu/install-samba-server-ubuntu-16-04) for more info.

--- a/_posts/2019-07-26-html5-best-practices.md
+++ b/_posts/2019-07-26-html5-best-practices.md
@@ -1,0 +1,240 @@
+---
+layout: page
+title: "HTML5 Best Practices"
+#category: 2.2
+date: 2019-07-26 17:34:41
+---
+
+When making a new component there is a recommended structure to follow and existing components to utilize to make your life easier.
+
+## Buttons
+
+There is a standard button component we use in the client. It is located inside of <b>/imports/ui/shared/Button.jsx</b>. It should be used for every button.
+
+## Font Size
+
+Inside of <b>/client/stylesheets</b> there is a stylesheet <b>fontSizing.css</b>.
+
+It will contain style classes such as extraSmallFont, smallFont, mediumFont, etc. Every piece of html with text to display to the client should be assigned one of these classes. This will allow text to scale responsively and still maintain relative size. You can set the class of an element to one of these classes, and have everything inside the container element inherit the font size rather than assign it to each individual child to save some work.
+
+# Localization
+
+
+The HTML5 client supports localizations by using the React-Intl  which allows the HTML5 client to have fully localized messages which are uploaded to Transifex for translating. As a result of this we have added the ability within the HTML5 client to switch the language of the application.
+
+The main language file is `en.json`. When there is a new field to localize, we update `en.json`, and then the new field string becomes available for crowdsourced translation on [Transifex](https://www.transifex.com)
+
+When declaring formatted messages we use  defineMessages and  injectIntl in place of FormattedMessage.
+
+~~~
+Import { injectIntl } from ‘react-intl’;          //pass’s messages as prop to the component
+import { defineMessages } from 'react-intl';      //import so we can group together all messages inside a component.
+
+const intlMessages = defineMessages({             //all messages can be defined in intlMessages
+  title: {
+	id: 'app.about.title', 	                        //id corresponds to the id in the locale file
+	description: 'About title label in Settings menu', //gives developers additional context about the element/item
+  },
+});
+~~~
+
+We omit the default message prop because it is the same as the string located in the locale file. By doing this we keep context of what the id’s mean while eliminating duplication.  Once the messages are defined we then add the following to use the `injectIntl`:
+
+~~~
+export default injectIntl(ComponentName);
+~~~
+
+From this point we can use the messages directly as they are passed down as props.
+
+~~~
+const { intl } = this.props;     //defined messages get passed as props
+
+<Button
+    role="button"
+    label={intl.formatMessage(intlMessages.title)}   	  //gets rendered to the screen
+    aria-label={intl.formatMessage(intlMessages.title)}    //voiced by screen reader
+/>
+~~~
+
+If the browser is requesting a locale file that does not contain all the translations, all the available strings will be merged with the locale file set as the default. In this case all messages will be displayed but may have a mixture of languages.
+
+If message id’s are missing from the locale file set as the default, and the browser requests the default or another locale containing a portion of the translated strings; there is potential for the missing id’s to not render a message and in this care default to the id of the message. To ensure this does not occur we make sure that the locale specified as the default always contains 100% of the used messages.
+
+## Server Calls
+
+
+To make a call to the server from the client, you should refer to the <b>callServer</b> function in <b>/imports/ui/services/api/index.js</b>.
+
+Always use this in favor of <b>Meteor.call</b>. The <b>callServer</b> function should operate the same way in that you pass the name of the method to call as a string, and then the arguments just like normal.
+
+[Meteor.call()](http://docs.meteor.com/#/full/meteor_call)
+
+
+# Project Structure
+
+<style type="text/css">
+pre
+{
+white-space: pre;
+overflow-x: auto;
+font-size: 0.85em;
+font-family: Monaco,Menlo,Consolas,"Courier New",monospace;
+}
+
+.comments{
+color: #A9A9A9;
+}
+</style>
+
+This section covers the structure for the HTML5 project
+
+## Meteor Structure
+
+<pre>
+imports/               
+  startup/                
+    client/               
+      index.js                      <span class="comments"># import client startup through a single index entity</span>
+      routes.js                     <span class="comments"># set up all routes in the app</span>
+      useraccounts-configuration.js <span class="comments"># configure login templates</span>
+    server/  
+      fixtures.js                   <span class="comments"># fill the DB with example data on startup</span>
+      index.js                      <span class="comments"># import server startup through a single index entity</span>
+
+  api/
+    lists/                          <span class="comments"># a unit of domain logic</span>
+      server/  
+        publications.js             <span class="comments"># all list-related publications</span>
+        publications.test.js        <span class="comments"># tests for the lists publications</span>
+      lists.js                      <span class="comments"># definition of the Lists collection</span>
+      lists.tests.js                <span class="comments"># tests for the behavior of that collection</span>
+      methods.js                    <span class="comments"># methods related to lists</span>
+      methods.tests.js              <span class="comments"># tests for those methods</span>
+
+  ui/  
+    components/                     <span class="comments"># all reusable components in the application</span>
+                                    <span class="comments"># can be split by domain if there are many</span>
+    layouts/                        <span class="comments"># wrapper components for behavior and visuals</span>
+    pages/                          <span class="comments"># entry points for rendering used by the router</span>
+
+client/  
+  main.js                           <span class="comments"># client entry point, import all client code</span>
+
+server/
+  main.js                           <span class="comments"># server entry point, import all server code</span>
+</pre>
+
+Taken from [Meteor Structure](http://guide.meteor.com/structure.html#example-app-structure)
+
+Inside imports is where we store all units of functionality for the HTML5 client.
+
+Inside API is where we store the collection data that we use, sort of like a model.
+
+Inside UI is where we store what would be the view for the models.
+
+
+## API
+
+
+Located under <b>/imports/api</b>
+
+Each sub-directory here will either be a data collection, or some service we use in the client.
+
+The name of the subdirectory should be in lower-case representing the name of the Mongo collection, or following typical programming collection it will be PascalCased representing a class name.
+
+Differing from the Meteor Structure is that for security purposes we want the majority of our functionality in the <b>/server</b> directory, which keeps it from loading on the clients.
+
+The main export or class for the API component should be in <b>index.js</b>, which allows for easy importing. So to import the Polling collection for example, we can use the following code `import Polls from 'imports/api/polls/'`.
+
+Since it is <b>index.js</b> we don’t have to specify that file since it is default.
+
+Naming files this way can conflict with certain conventions where the file name is named after the main class inside it. To go about this we simply have a default export for the collections, and in the case of a collection we export the new instance.
+
+Inside the <b>/server</b> directory of every API component we have a named file named publications.js. This is where we put the Meteor publish callback for the collection.
+
+We now have 2 more sub-directories inside the <b>/server</b> directory-- methods and modifiers.
+
+### /methods
+
+Inside <b>/methods</b> we have one file per method. These methods are where we declare the Meteor.Methods for the collection-- which are Meteor server methods that can be invoked from the Meteor client. We have one file per method, and they are named in camelCase. They shouldn’t need an export because of how they are registered in Meteor. They will however have to be imported on the server (at startup) to execute the code.
+
+### /modifiers
+
+Inside <b>/modifiers</b> we have one file per method. These functions that go in here include the functions that modify the <b>collection/data/class</b>, from the server side. We have one file per method, and they are named in camelCase. There should be one export per file. And these will be imported wherever needed. These are almost all functions that will be called from Redis message listeners.
+
+### eventHandlers.js
+
+Inside `imports/api/<collection>/server/` we have a file called `eventHandlers.js`. This file will contain all the event handlers for the collection.
+
+/ui
+---
+
+Inside /ui we will have sub-directories for
+
+-   components
+
+-   services
+
+-   stylesheets
+
+### /services
+
+will have <b>/api/index.js</b>. Which is where we will store client-side-wide services and helpers. The functions and data in here will all be exported on the last line of the file in one export statement. This allows someone to just look at the last line of the file and easily see what the file exports.
+
+### /components
+
+Inside this directory each sub-directory will represent a React Component. The name of the sub-directory is what the name of the component is. They are all lowercase, with dashes (-) between words. The standard file are
+
+-   component.jsx
+
+-   container.jsx
+
+-   service.js
+
+-   styles.scss
+
+Example
+
+-&gt; /whiteboard
+
+&emsp; &emsp;-&gt; component.jsx
+
+&emsp; &emsp;-&gt; service.js
+
+&emsp; &emsp;-&gt; container.js
+
+&emsp; &emsp;-&gt; /slide/component.jsx
+
+&emsp; &emsp;-&gt; /cursor/component.jsx
+
+&emsp; &emsp;-&gt; /shape-factory/component.jsx
+
+&emsp; &emsp;-&gt; /shapes
+
+&emsp; &emsp; &emsp; &emsp;-&gt; /ellipse/component.jsx
+
+&emsp; &emsp; &emsp; &emsp;-&gt; /triangle/component.jsx
+
+&emsp; &emsp; &emsp; &emsp;-&gt; ... &lt;the rest of the shape components&gt;
+
+#### Component
+
+All components will be React ES6 style classes (not React Classes). A component should only need to have one export and it should be the default export. Refer to the official React documentation on how to structure a component class. The component file will be named <b>component.jsx</b>.
+
+#### Container
+
+[createContainer()](http://guide.meteor.com/react.html#using-createContainer)
+
+A container is a React ES6 class that will pass data to the component. The container will also be in control of whether or not the component should render. A container should retrieve data from the service and pass it into the container class.
+
+The container file will be named <b>container.jsx</b>. The file should have only one export and should be the default export. The export should be the result of the `createContainer()` function.
+
+#### Service
+
+The service file should be named <b>service.js</b>.
+
+The file can export as many function, objects, or other pieces of data as it needs. The service can interface with other collections as well. There should only be one export statement in the file. The last line of the file should export all the functions and pieces of data in an object. Restrain from wrapping everything inside a function and exporting the function wrapper.
+
+#### Styles.scss
+
+All styles should be written in SASS when possible.

--- a/_posts/2019-07-29-22-legacy-dev.md
+++ b/_posts/2019-07-29-22-legacy-dev.md
@@ -1,0 +1,665 @@
+---
+layout: page
+title: "Legacy Development Environment"
+#category: 2.2
+date: 2019-07-26 17:34:41
+---
+
+*The following document is only required if you're interested in developing the legacy Flash client and it's associated projects.*
+
+# Legacy Tools
+
+You need to make a directory to hold the tools needed for BigBlueButton Flash client development.
+
+~~~
+mkdir -p ~/dev/tools
+cd ~/dev/tools
+~~~
+
+In the next step, you need to get the Apache Flex 4.13.0 SDK package. 
+
+First, you need to download the SDK tarball from an Apache mirror site and then unpack it.
+
+~~~
+wget https://archive.apache.org/dist/flex/4.13.0/binaries/apache-flex-sdk-4.13.0-bin.tar.gz
+tar xvfz apache-flex-sdk-4.13.0-bin.tar.gz
+~~~
+
+Once the Apache Flex SDK is unpacked, you need to download one of the dependencies manually because the file was moved from its original URL.
+
+~~~
+wget --content-disposition https://github.com/swfobject/swfobject/archive/2.2.tar.gz
+tar xvfz swfobject-2.2.tar.gz
+cp -r swfobject-2.2/swfobject apache-flex-sdk-4.13.0-bin/templates/
+~~~
+
+Now that we've finished with the first dependency we need to download the Adobe Flex SDK.  We'll do this step manually in case the download fails (if it does, remove the incomplete file and issue the `wget` command again).
+
+~~~
+cd apache-flex-sdk-4.13.0-bin/
+mkdir -p in/
+wget http://download.macromedia.com/pub/flex/sdk/builds/flex4.6/flex_sdk_4.6.0.23201B.zip -P in/
+~~~
+
+Once the supplementary SDK has downloaded, we can use its `build.xml` script to automatically download the remaining third-party tools.
+
+~~~
+ant -f frameworks/build.xml thirdparty-downloads
+~~~
+
+After Flex downloads the remaining third-party tools, you need to modify their permissions.
+
+~~~
+find ~/dev/tools/apache-flex-sdk-4.13.0-bin -type d -exec chmod o+rx '{}' \;
+chmod 755 ~/dev/tools/apache-flex-sdk-4.13.0-bin/bin/*
+chmod -R +r ~/dev/tools/apache-flex-sdk-4.13.0-bin
+~~~
+
+Next, create a linked directory with a shortened name for easier referencing.
+
+~~~
+ln -s ~/dev/tools/apache-flex-sdk-4.13.0-bin ~/dev/tools/flex
+~~~
+
+The next step in setting up the Flex SDK environment is to download a Flex library for video.
+
+~~~
+mkdir -p ~/dev/tools/apache-flex-sdk-4.13.0-bin/frameworks/libs/player/11.2
+cd ~/dev/tools/apache-flex-sdk-4.13.0-bin/frameworks/libs/player/11.2
+wget http://fpdownload.macromedia.com/get/flashplayer/installers/archive/playerglobal/playerglobal11_2.swc
+mv -f playerglobal11_2.swc playerglobal.swc
+~~~
+
+The last step to have a working Flex SDK is to configure it to work with playerglobal 11.2
+
+~~~
+cd ~/dev/tools/apache-flex-sdk-4.13.0-bin
+sed -i "s/11.1/11.2/g" frameworks/flex-config.xml
+sed -i "s/<swf-version>14<\/swf-version>/<swf-version>15<\/swf-version>/g" frameworks/flex-config.xml
+sed -i "s/{playerglobalHome}\/{targetPlayerMajorVersion}.{targetPlayerMinorVersion}/libs\/player\/11.2/g" frameworks/flex-config.xml
+~~~
+
+With the tools installed, you need to add a set of environment variables to your `.profile` to access these tools.
+
+~~~
+vi ~/.profile
+~~~
+
+Copy-and-paste the following text at bottom of `.profile`.
+
+~~~
+
+export FLEX_HOME=$HOME/dev/tools/flex
+export PATH=$PATH:$FLEX_HOME/bin
+
+
+export ANT_OPTS="-Xmx512m -XX:MaxPermSize=512m"
+
+~~~
+
+Reload your profile to use these tools (this will happen automatically when you next login).
+
+~~~
+source ~/.profile
+~~~
+
+Check that the tools are now in your path by running the following command.
+
+~~~
+$ mxmlc -version
+Version 4.13.0 build 20140701
+~~~
+
+# Flash Client Development
+
+This section will walk you through making a simple change to the BigBlueButton Flash client.
+
+## Setting up the environment
+
+The first thing you need to do is to copy the template `config.xml` file to the build directory for the client.
+
+~~~
+cd ~/dev/bigbluebutton/
+cp bigbluebutton-client/resources/config.xml.template bigbluebutton-client/src/conf/config.xml
+~~~
+
+The `config.xml` file is one of the first files loaded by the BigBlueButton client when it connects to the server.  The `config.xml` file tells BigBlueButton client how to load the remaining components (such as chat module, deskshare module, video conf module, etc.) and sets a number of configuration parameters for each component.  The `config.xml` specifies the hostname (or IP address) for loading each component.
+
+Let's look at the first ten lines of the `config.xml` file you just copied.
+
+~~~
+$ head -n 10 bigbluebutton-client/src/conf/config.xml
+<?xml version="1.0" ?>
+<config>
+    <localeversion suppressWarning="false">0.9.0</localeversion>
+    <version>VERSION</version>
+    <help url="http://HOST/help.html"/>
+    <javaTest url="http://HOST/testjava.html"/>
+    <porttest host="HOST" application="video/portTest" timeout="10000"/>    
+    <bwMon server="HOST" application="video/bwTest"/>
+    <application uri="rtmp://HOST/bigbluebutton" host="http://HOST/bigbluebutton/api/enter"/>
+    <language userSelectionEnabled="true" />
+~~~
+
+You will see the word `HOST` where there would be configured hostname/IP address.  You need to change the text `HOST` to the IP address (or hostname) of your BigBlueButton server.  For example, if the IP address of your BigBlueButton server is `192.168.1.145`, then using the following command you can easily substitute all occurrences of `HOST` with `192.168.1.145`.
+
+Note: Don't copy-and-paste the following command as-is: the address `192.168.1.145` is likely not the correct IP address (or hostname) for your BigBlueButton server.  Substitute the IP address (or hostname) for your BigBlueButton server.
+
+~~~
+sed -i s/HOST/192.168.1.145/g bigbluebutton-client/src/conf/config.xml
+~~~
+
+After you've done the above command, take a quick look at the file and ensure all instances of `HOST` are properly replaced with the IP address (or hostname) of your BigBlueButton server.
+
+The `config.xml` is ultimately loaded by the BigBlueButton client when a user joins a session on the server.  
+
+Later on, when you deploy your modified client to the BigBlueButton server, there will be two BigBlueButton clients on your server: your modified BigBlueButton client and the default BigBlueButton packaged client (again, this is good as you can switch back and forth). However, the BigBlueButton configuration command `sudo bbb-conf ` only modifies the packaged BigBlueButton client and you will need to mirror any changes to the packaged config.xml to the secondary client's config.xml.
+
+Next, you need to setup nginx to redirect calls to the client towards your development version. If you don't already have an nginx client development file at `/etc/bigbluebutton/nginx/client_dev`, create one with the following command.
+
+**NOTE:** Make sure to replace "ubuntu" with your own username if it's different.
+
+~~~
+echo "
+location /client/BigBlueButton.html {
+	root /home/ubuntu/dev/bigbluebutton/bigbluebutton-client;
+	index index.html index.htm;
+	expires 1m;
+}
+
+# BigBlueButton Flash client.
+location /client {
+	root /home/ubuntu/dev/bigbluebutton/bigbluebutton-client;
+	index index.html index.htm;
+}
+" | sudo tee /etc/bigbluebutton/nginx/client_dev 
+~~~
+
+Check the contents to ensure it matches below.
+
+Again, make sure you change `/home/ubuntu` to match your home directory.
+
+~~~
+$ cat /etc/bigbluebutton/nginx/client_dev
+
+location /client/BigBlueButton.html {
+	root /home/ubuntu/dev/bigbluebutton/bigbluebutton-client;
+	index index.html index.htm;
+	expires 1m;
+}
+
+# BigBlueButton Flash client.
+location /client {
+	root /home/ubuntu/dev/bigbluebutton/bigbluebutton-client;
+	index index.html index.htm;
+}
+~~~
+
+These rules tell nginx where to find the BigBlueButton client.  Currently, nginx is using the rules with the default BigBlueButton client through a symbolic link.
+
+~~~
+$ ls -al /etc/bigbluebutton/nginx/client.nginx
+lrwxrwxrwx 1 root root 31 2013-05-05 15:44 /etc/bigbluebutton/nginx/client.nginx -> /etc/bigbluebutton/nginx/client
+~~~
+
+Modify this symbolic link so it points to the development directory for your BigBlueButton client.
+
+~~~
+sudo ln -f -s /etc/bigbluebutton/nginx/client_dev /etc/bigbluebutton/nginx/client.nginx
+~~~
+
+Check that the modifications are in place.
+
+~~~
+$ ls -al /etc/bigbluebutton/nginx/client.nginx
+lrwxrwxrwx 1 root root 35 2013-05-05 21:07 /etc/bigbluebutton/nginx/client.nginx -> /etc/bigbluebutton/nginx/client_dev
+~~~
+
+Now we need to restart nginx so our changes take effect.
+
+~~~
+$ sudo systemctl restart nginx
+$ sudo systemctl status nginx
+● nginx.service - A high performance web server and a reverse proxy server
+   Loaded: loaded (/lib/systemd/system/nginx.service; enabled; vendor preset: enabled)
+   Active: active (running) since Sun 2017-01-15 22:43:31 UTC; 9s ago
+  Process: 14264 ExecStop=/sbin/start-stop-daemon --quiet --stop --retry QUIT/5 --pidfile /run/nginx.pid (code=exited, status=0/SUCCESS)
+  Process: 14266 ExecStart=/usr/sbin/nginx -g daemon on; master_process on; (code=exited, status=0/SUCCESS)
+  Process: 14265 ExecStartPre=/usr/sbin/nginx -t -q -g daemon on; master_process on; (code=exited, status=0/SUCCESS)
+ Main PID: 14267 (nginx)
+    Tasks: 9
+   Memory: 5.6M
+      CPU: 37ms
+   CGroup: /system.slice/nginx.service
+           ├─14267 nginx: master process /usr/sbin/nginx -g daemon on; master_process on
+           ├─14268 nginx: worker process
+           ├─14269 nginx: worker process
+           ├─14270 nginx: worker process
+           ├─14271 nginx: worker process
+           ├─14272 nginx: worker process
+           ├─14273 nginx: worker process
+           ├─14274 nginx: worker process
+           └─14275 nginx: worker process
+
+Jan 15 22:43:31 t4 systemd[1]: Starting A high performance web server and a reverse proxy server...
+Jan 15 22:43:31 t4 systemd[1]: Started A high performance web server and a reverse proxy server.
+
+~~~
+
+Now, when you launch the BigBlueButton client, nginx will serve the client from your development directory.  Next, we need to rebuild the client.
+
+## Building the client
+Let's now build the client.  Note we're going to build and run the client to make sure it works before making any changes to the source.
+
+First, we'll build the locales (language translation files).  If you are not modifying the locales, you only need to do this once.
+
+~~~
+cd ~/dev/bigbluebutton/bigbluebutton-client
+ant locales
+~~~
+
+This will take about 10 minutes (depending on the speed of your computer).  Next, let's build the client
+
+~~~
+ant
+~~~
+
+This will create a build of the BigBlueButton client in the `/home/ubuntu/dev/bigbluebutton/bigbluebutton-client/client` directory.
+
+**Note:** The BigBlueButton server will cache the config.xml for a given meetingID.  To ensure you load the new config.xml you must restart your BigBlueButton server after making a change to the config.xml.
+
+The above note is important.  It's easy to make a quick change to your `config.xml` and wonder why the change is not reflected when you load the client.  You need to restart BigBlueButton using 
+
+~~~
+sudo bbb-conf --clean
+~~~
+
+After this, point your browser to your BigBlueButton server and login to the demo page.  The client should start properly.
+
+Note: You could have also restart BigBlueButton with `sudo bbb-conf --restart`, but it's a good idea to pass `--clean` instead as it cleans out all the log files between restarts and thereby wipes any previous errors.
+
+**Note:** On the bottom of the client you'll see "VERSION", but that's OK.  It is usually replaced by the latest build number when packaging is done.  If you see "VERSION", this is good as BigBlueButton is now loading your own copy of the client (and not the packaged version).
+
+If you execute `sudo bbb-conf --check`, you'll notice it gives a warning
+
+~~~
+** Potential problems described below **
+# Warning: nginx is not serving the client from /var/www/bigbluebutton/.
+# Instead, it's being served from
+#
+#    /home/ubuntu/dev/bigbluebutton/bigbluebutton-client
+#
+# (This is OK if you have setup a development environment.)
+~~~
+
+This is good -- it's another confirmation that the BigBlueButton server is serving your development client (not the packaged version).
+
+## Making a change
+
+Now that we have successfully built and loaded the client from a development environment, let's make a small visible change to the interface.  We're using `vi` to edit the client, but you can use any Unix text editor of course.
+
+**Note:** If you are on Windows and developing using a VM, you may find it easier to setup [Samba](20dev.html#setup-samba) so you can access your files through Windows Explorer and use a Windows editor.  You can then browse the network from your Windows computer and find the shared volume.  Once mounted in Windows (usually with a drive letter such as d: or e:), you can access the files directly with your editor on Windows.
+
+
+~~~
+cd ~/dev/bigbluebutton/bigbluebutton-client
+vi src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+~~~
+
+Once you have `MainApplicationShell.mxml` open, go to line 680 and you'll see the following text
+
+~~~mxml
+<mx:Text htmlText="{ResourceUtil.getInstance().getString('bbb.mainshell.copyrightLabel2',[appVersion])}" id="copyrightLabel2"/>
+~~~
+
+Insert the text ' -- BigBlueButton Rocks!!' as shown below.
+
+~~~mxml
+<mx:Text htmlText="{ResourceUtil.getInstance().getString('bbb.mainshell.copyrightLabel2',[appVersion])} -- BigBlueButton Rocks!!!" id="copyrightLabel2"/>
+~~~
+
+
+Now, rebuild the BigBlueButton client again.
+
+~~~
+ant
+~~~
+
+When done, join the demo meeting using the client. You'll see the message `-- BigBlueButton Rocks!` added to the copyright line.
+
+![rocks](/images/rocks.png)
+
+If you don't see your changes, **try clearing your browser's cache and then load the client again**.  It also might be easier to just try this using Firefox since it most likely will not cache this.
+
+## Switching back to the packaged client
+
+To switch back to using the packaged BigBlueButton client anytime, you only need to change the symbolic link for nginx and then restart BigBlueButton (again, this reloads the `config.xml` file for the client).
+
+~~~
+sudo ln -s -f /etc/bigbluebutton/nginx/client /etc/bigbluebutton/nginx/client.nginx
+sudo bbb-conf --clean
+~~~
+
+To switch back to your development setup, simply recreate the symbolic link and restart nginx.
+
+~~~
+sudo ln -s -f /etc/bigbluebutton/nginx/client_dev /etc/bigbluebutton/nginx/client.nginx
+sudo bbb-conf --clean
+~~~
+
+## Using Flex/Flash Builder
+
+These steps assume that you have a local BigBlueButton development server on your network (or in a virtual machine).  The steps will have you install Samba on the server to give your Windows/Mac access to the file system to make code edits directly.  
+
+Do not install samba on a BigBlueButton server on the internet.  Instead, if you want to use Flex/Flash Builder, first setup a local BigBlueButton server on your network (or in a virtual machine) and make the changes locally.  After you've updated the local BigBlueButton server, copy to modified files (and update any necessary configuration changes) to the remote BigBlueButton server.
+
+To develop the client using Flash Builder on a local BigBlueButton server (we'll refer to the local server as the BigBlueButton VM, but it need not be a virtual machine you have for development), follow these steps:
+
+  1. Install Flash Builder on your Windows/Mac machine.
+
+  1. Setup samba on the BigBlueButton VM (use the command `sudo bbb-conf --setup-samba`) and mount the VM drive as described earlier in this document.
+
+  1. In Flash Builder, import the project by going to _File_ -> _Import_ -> _Existing Projects into Workspace_.
+
+     1. Select the _Project Folder_ radio
+
+     1. Click _Browse_ and choose the bigbluebutton-client directory in your BigBlueButton VM. For example W:\dev\source\bigbluebutton\bigbluebutton-client
+
+     1. Click _Finish_.
+
+  1. From the BigBlueButton VM, copy the Flex SDK from ~/dev/tools into the Flash Builder SDK directory. You can see the location on the image below. Then, in Flash Builder, click _Window_ -> _Preferences_ -> _Installed Flex SDKs_ and _Add_ the SDK you have just copied. 
+
+![flex-sdk](/images/flex/flex-sdk.png)
+
+  1. Right-click on the project, go to _Properties_ -> _Flex Compiler_, and change the Flex version to 4.13. Make sure the Flash Player specific version is set to at least 11.2.0. Also, check the _Flex 3 compatibility mode_ option (The BigBlueButton client uses Flex 3 components). Click _Apply_. 
+
+![flex-compiler](/images/flex/flex-compiler.png)
+
+  1. Right-click on the project, click _Properties_ -> _Flex Build Path_. Click on _MX only_ component set. Make sure the libs directory is present in the _Library path_.
+
+![flex-build-path](/images/flex/flex-build-path.png)
+
+## Debugging with Flash Builder
+
+  First we will set up our Flash Builder project for debugging.
+	
+  1. Right-click on the project, go to _Debug As_ -> _Debug Configurations...._
+
+  1. Right-click on _Web Application_ -> _New_
+  
+  1. Make sure the BigBlueButton client is in the _Project_ section and src/BigBlueButton.mxml is in the _Application file_.
+  
+  1. Deselect _Use default_ and change the path to _about:blank_
+  
+  1. Select _Apply_ and _Close_
+  
+  Flash Builder is now set up to debug with a client running remotely (ie. on your VM). It is important to note that you must still build the client using `ant` in your VM because Flash Builder won't build the full client.
+
+![flex-debug](/images/flex/flex-debug.png)
+  
+  Before you are able to debug you need to have a browser installed and the [debug version](http://www.adobe.com/support/flashplayer/debug_downloads.html) of Flash Player Debug for it.
+  
+  To start debugging:
+  
+  1. Start a BigBlueButton session.
+  
+  1. In Flash Builder, open the _Debug Configurations..._, select your previously created configuration, select _Debug_
+  
+  1. Go back to browser and right-click the Flash content, select _Debugger_, select _Localhost_
+  
+  1. In Flash Builder, wait for the launch progress to get above 50%
+  
+  1. Go back to your broswer and select _Connect_
+  
+  The debugger should now be connected and you should see output in the Flash Builder Console and breakpoints will activate. An alternative to steps 3-5 is to wait for the progress to get above 50% and then reload the BigBlueButton.html page in browser. The debugger should automatically connect when the Flash content has loaded.
+  
+  If you can see messages in the Flash Builder Console, but breakpoints aren't working you need to make sure that the version of the client in Flash Builder is the same as the version on your server. To do this do a full build of the client with `ant` on your server and refresh the project in Flash Builder (right-click the project -> _Refesh_) before running the debugger again. Sometimes the debugger still won't work after a refresh and you have to restart Flash Builder to get it running again.
+
+# Pulling localization from Transifex
+
+To pull the localization from Transifex, do the following steps
+
+1. Install the Transifex client for Ubuntu
+
+~~~
+sudo apt-get install python-pip -y
+sudo pip install transifex-client
+~~~
+
+2. Go to the locale folder
+
+~~~
+cd ~/dev/bigbluebutton/bigbluebutton-client/locale 
+~~~
+
+3. Initialize the Transifex project
+
+~~~
+tx init
+
+# Insert your transifex user and password
+~~~
+	
+4. Set the BigBlueButton transifex resource
+
+~~~
+tx set --auto-remote https://www.transifex.com/projects/p/bigbluebutton/resource/bbbresourcesproperties/
+~~~
+
+5. Edit the Transifex configuration file to filter the languages to match the BBB repository
+
+~~~
+vi .tx/config
+
+file_filter = <lang>/bbbResources.properties 
+~~~
+
+6. Update all the languages from Transifex (updates only the languages existing in the current directory where the command is executed)
+
+~~~
+tx pull -f
+~~~
+
+    Pull all the languages from Transifex (download also languages which don't exist in the local directory where the command is executed, may download undesired language directories [lt, es_429])
+
+~~~
+tx pull -a --mode=onlytranslated
+~~~
+
+7. Sometimes Transifex downloads es_419 instead of es_LA (Latin American Spanish), in that case we need to manually update es_LA with what is in es_419
+
+~~~
+rm -r es_LA
+cp es_419 es_LA
+~~~
+
+8. Add a gitignore to ignore the .tx folder or remove the .tx folder that is hidden
+
+~~~
+nano .gitignore
+.tx
+~~~
+
+or
+
+~~~
+rm -r .tx
+~~~
+
+9. Compile to check you didn't break anything
+
+~~~
+cd ~/dev/bigbluebutton/bigbluebutton-client
+ant locales
+~~~
+
+# Developing BBB-Client-Check
+
+First, let's navigate to the source code for the component
+
+~~~
+cd ~/dev/bigbluebutton/bbb-client-check
+~~~
+
+Then modify the configurations fileto substitute your IP or domain name for the word HOST.
+
+~~~
+sed -i s/HOST/<IP or domain name>/g resources/config.xml.template
+~~~
+
+Next, let's build the component
+
+~~~
+ant
+~~~
+
+This will create a build of the bbb-client-check component in the `/home/ubuntu/dev/bigbluebutton/bbb-client-check/check` directory.
+
+Next we need to create an nginx file to redirect calls to your development bbb-client-check.
+
+~~~
+echo "
+location /check {
+	root /home/ubuntu/dev/bigbluebutton/bbb-client-check;
+	index index.html index.htm;
+}
+" | sudo tee /etc/bigbluebutton/nginx/check.nginx > /dev/null 2>&1
+~~~
+
+Now restart nginx and test the configuration:
+
+~~~
+sudo /etc/init.d/nginx restart
+sudo nginx -t
+~~~
+
+At this point you should be able to navigate to the check client page in your browser and use it. (e.x. http://demo.bigbluebutton.org/check)
+
+When you make a change you will need to run `ant` again to rebuild the module.
+
+# Developing the Red5 Applications
+
+You need to make `red5/webapps` writeable. Otherwise, you will get a permission error when you try to deploy into Red5.
+
+~~~
+sudo chmod -R 777 /usr/share/red5/webapps
+~~~
+
+## Developing BBB-Apps
+
+Before you build and deploy bbb-apps you need to make sure that red5 service is stopped.
+
+~~~
+sudo systemctl stop red5
+~~~
+
+First we have to compile bbb-apps-common
+
+~~~
+cd ~/dev/bigbluebutton/bbb-apps-common
+sbt clean
+sbt publish publishLocal
+~~~
+
+Now you can compile and deploy bigbluebutton-apps.
+
+~~~
+cd ~/dev/bigbluebutton/bigbluebutton-apps
+./deploy.sh
+~~~
+
+And finally, you can start the red5 service up again.
+
+~~~
+sudo systemctl start red5
+~~~
+
+## Developing BBB-Video
+
+First, you need to stop red5.
+
+~~~
+sudo systemctl stop red5
+~~~
+
+Then you can compile and deploy the application.
+
+~~~
+cd ~/dev/bigbluebutton/bbb-video
+gradle resolveDeps
+gradle war deploy
+~~~
+
+And finally, start red5 up again.
+
+~~~
+sudo systemctl start red5 
+~~~
+
+## Developing BBB-Voice
+
+First, you need to stop red5.
+
+~~~
+sudo systemctl stop bbb-red5 
+~~~
+
+Then you can compile and deploy the application.
+
+~~~
+cd ~/dev/bigbluebutton/bbb-voice
+gradle resolveDeps
+gradle war deploy
+~~~
+
+And finally, start red5 up again.
+
+~~~
+sudo systemctl start bbb-red5 
+~~~
+
+## Developing Screen Sharing
+
+See the the [README](https://github.com/bigbluebutton/bigbluebutton/tree/master/bbb-screenshare) file in the `bbb-screenshare` directory for details on how to compile and sign the Screen Sharing applet.
+
+# Troubleshooting
+
+## Connecting to the server
+When the BigBlueButton client loads, it runs a number of modules: chat, voice, desktop sharing, and presentation.  Each of these modules makes a connection back to their corresponding BigBlueButton server components.
+
+The URL for each connection is specified in [config.xml](/install/configuration-files.html#modules).
+
+When setting up a development environment for the client, the `config.xml` file for the BigBlueButton client is now loaded from `~/dev/bigbluebutton/bigbluebutton-client/client/conf/config.xml`.  This means that any changes made to the default `config.xml` by `sudo bbb-conf --setip <hostname>` will _not_ affect the `config.xml` in your development environment.  Thus, if you change your hostname or IP address for the BigBlueButton server, you'll need to manually change the `config.xml` for your development environment.
+
+## Old Translation
+If you get a "Old Translation" warning when starting the client, in `/var/www/bigbluebutton/client/conf/config.xml` change
+
+~~~xml
+<localeversion suppressWarning="false">0.71</localeversion>
+~~~
+
+to
+
+~~~xml
+<localeversion suppressWarning="false">0.9.0</localeversion>
+~~~
+
+## Warning: Try increasing the code cache size
+
+If you get a compiler warning during the building of bbb-client, such as
+
+~~~
+build-polling:
+    [mxmlc] Loading configuration file /home/dwelch/dev/tools/flex-4.5.0.20967/frameworks/flex-config.xml
+OpenJDK 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.
+OpenJDK 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=
+    [mxmlc] /home/dwelch/dev/bigbluebutton/bigbluebutton-client/client/PollingModule.swf (232039 bytes)
+~~~
+
+Add the following to `~/.profile`
+
+~~~
+export ANT_OPTS="-Xmx512m -XX:MaxPermSize=512m -XX:ReservedCodeCacheSize=1024m"
+~~~
+
+and then reload the .profile with the command `source ~/.profile`.


### PR DESCRIPTION
I put the 2.0 dev instructions back in the 2.2 dev instructions so people can still build non-HTML5 core components. I moved all the stuff in the 2.2 dev instructions about the HTML5 client, but not directly related to development, out into their own pages. There's no a best practices page and restored the HTML5 overview page. I split the Flash related dev instructions in a `legacy` page so it will be easier to remove in the future and doesn't clutter the main page.

I also added the HTML5 code to the architecture page.