### PR TITLE
update FAQ required open tcp ports

### DIFF
--- a/_posts/2015-04-05-faq.md
+++ b/_posts/2015-04-05-faq.md
@@ -471,7 +471,7 @@ For the above reasons, we recommend you setup BigBlueButton on a dedicated serve
 
 ### What ports must be open for external users to connect to BigBlueButton
 
-For TCP ports, clients must be able to connect to the BigBlueButton server on port 80/443 (HTTP/HTTPS), 7443 (audio), and 1935 (RTMP).  
+For TCP ports, clients must be able to connect to the BigBlueButton server on port 80/443 (HTTP/HTTPS).  
 
 For UDP ports, clients must be able to connect on a port within the range 16384-32767 for WebRTC-based audio.
 

--- a/_posts/2019-02-14-configure-firewall.md
+++ b/_posts/2019-02-14-configure-firewall.md
@@ -78,29 +78,29 @@ $ sudo apt-get install netcat
 Next, stop BigBlueButton with the command `sudo bbb-conf --stop`.  This frees up the ports we want to test.  We can now run `netcat` to listen on ports and try connecting from an external computer.   As root, run the following command:
 
 ```bash
-$ netcat -l 7443
+$ netcat -l 443
 ```
 
-`netcat` is now going to echo to the terminal any text it receives on port 7443 (you can quit the command later using Ctrl-c).
+`netcat` is now going to echo to the terminal any text it receives on port 443 (you can quit the command later using Ctrl-c).
 
 Next, on a second computer that is external to the firewall -- that is, it must go through the firewall to access the BigBlueButton server -- install `netcat` as well.  Replace `EXTERNAL_HOST_NAME` with the hostname of your firewall, run the following command
 
 ```bash
-$ netcat EXTERNAL_HOST_NAME 7443
+$ netcat EXTERNAL_HOST_NAME 443
 ```
 
 and type type the word 'test' and press ENTER.  
 
-If the firewall is forwarding incoming connections on port 7443 to the internal BigBlueButton server, you should see the word 'test' appear after the `netcat -l 7443` command, as in
+If the firewall is forwarding incoming connections on port 443 to the internal BigBlueButton server, you should see the word 'test' appear after the `netcat -l 443` command, as in
 
 ```bash
-$ netcat -l 7443
+$ netcat -l 443
 test
 ```
 
-If the word `test` does not appear, double-check the firewall configuration to ensure its forwarding connections on port 7443 and then test again.  You want to see the word `test` appear before proceeding to the installation BigBlueButton.
+If the word `test` does not appear, double-check the firewall configuration to ensure its forwarding connections on port 443 and then test again.  You want to see the word `test` appear before proceeding to the installation BigBlueButton.
 
-Repeat these tests with ports 80, 443, and 1935.
+Repeat these tests with port 80.
 
 That covers the TCP/IP ports.  Next, we need to test that UDP connections in the range 16384-32768 are forwarded as well.  On your BigBlueButton server, run the following `netcat` command to listen for incoming data via UDP on port 17000 (here, we're picking a port in the range 16384-32768).
 


### PR DESCRIPTION
### What does this PR do?
Update FAQ regarding required open tcp ports. 1935 and 7443 don't have to (and should not) be open to the internet.

### Additional Notes
This FAQ answer differed from the [bbb configure-firewall documentation](https://docs.bigbluebutton.org/2.2/configure-firewall.html) and probably just wasn't updated.
Closes https://github.com/bigbluebutton/bigbluebutton/issues/9132