### PR TITLE
move how to report security issues below all the how to git questions

### DIFF
--- a/_posts/2015-04-05-faq.md
+++ b/_posts/2015-04-05-faq.md
@@ -215,9 +215,6 @@ To obtain a committer agreement, download [BigBlueButton Inc. Contributor Agreem
 
 Once we receive the signed Contributor Agreement, we can review your submission for inclusion in BigBlueButton.  The process for submission depends on whether it's fixing a bug (submitting a pull request) or whether it's an enhancement (submitting a feature).
 
-## Where should I report potential security issues?
-You can email Fred Dixon, the product manager for BigBlueButton, at ffdixon .at. bigbluebutton .dot. org.
-
 ### Submission of a pull request
 
 If you want to submit a pull request, your chances of acceptance are **greatly** improved if the following are true:
@@ -274,6 +271,9 @@ For code written in Java, we follow the [Java Coding Convention](http://www.orac
 For documentation of code method -- especially those classes that provides an API to other classes -- should be documented using the [JavaDoc](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html) format.
 
 For Flex/ActionScript code, follow the [AsDoc](https://flex.apache.org/asdoc/) format.
+
+## Where should I report potential security issues?
+You can email Fred Dixon, the product manager for BigBlueButton, at ffdixon .at. bigbluebutton .dot. org.
 
 # Installation
 


### PR DESCRIPTION
currently `## Where should I report potential security issues?` shows up as parent topic for all the git repo related questions+answers. This change moved the report security issues question+answer below these git related questions, thus fixing the table of contents