### PR TITLE
Master+ufw note

### DIFF
--- a/_posts/2019-02-14-configure-firewall.md
+++ b/_posts/2019-02-14-configure-firewall.md
@@ -14,20 +14,20 @@ If you are a developer setting up BigBlueButton on a local VM for testing, you c
 
 # Overview
 
-The easiest network configuration for installing BigBlueButton is on a server that has a single external IP address, the server is on the public Internet (and thus directly accessible by your users), and there is no firewall (virtual or physical) between users and the server.  Here is an example of such a setup with the BigBlueButton server having a (fictional) IP address 203.0.113.1 with hostname `bigbluebutton.example.com`.
+The easiest network configuration for installing BigBlueButton is on a server that has a single external IP address and the server is on the public Internet (and thus directly accessible by your users). Port-based access firewalling is implemented using [UFW](2.2/customize.html#secure-your-system--restrict-access-to-specific-ports).  Here is an example of such a setup with the BigBlueButton server having a (fictional) IP address 203.0.113.1 with hostname `bigbluebutton.example.com`.
 
 ![Install](/images/11-install-net0.png)
 
-In this simple network configuration, BigBlueButton should work out-of-the-box after installation.  This is because the packaging scripts automatically configure BigBlueButton using the first non-loopback IP address.    
+In this simple network configuration, BigBlueButton should work out-of-the-box after installation.  This is because the packaging scripts automatically configure BigBlueButton using the first non-loopback IP address, whereas access to sensitive ports is blocked.    
 A variation of this setup occurs when the server has multiple network interfaces, but the external IP is still the first network interface (such as `eth0`) picked up by the installation scripts.  
 
 ![Install](/images/11-install-net1.png)
 
-If your server has `eth0` pointing to the external IP address on the internet, and there is no other firewall in place, then the packaging scripts should detect this external IP address and configure BigBlueButton accordingly.  You don't need to do any of the changes below.
+If your server has `eth0` pointing to the external IP address on the internet, and there is no external firewall in place, then the packaging scripts should detect this external IP address and configure BigBlueButton accordingly.  You don't need to do any of the changes below.
 
 Don't worry if your server's IP address changes, BigBlueButton comes with a configuration utility called `bbb-conf` that lets you change all of BigBlueButton's configuration files to use any IP address or hostname.
 
-If there is a firewall between your users and the BigBlueButton server, then you will need to first configure the firewall to forward specific TCP/UDP connections from external clients to the internal BigBlueButton server; otherwise, users will not be able to access BigBlueButton.
+If there is an IPv4 Network Address Translation (NAT) between your users and the BigBlueButton server, then you will need to first configure the firewall to forward specific TCP/UDP connections from external clients to the internal BigBlueButton server; otherwise, users will not be able to access BigBlueButton.
 
 The following diagram gives a typical setup with an external firewall (your setup will, of course, have different IP address and hostnames).
 

--- a/_posts/2019-02-14-customize.md
+++ b/_posts/2019-02-14-customize.md
@@ -42,11 +42,13 @@ swfSlidesRequired=false
 
 The SWF files are not needed by the HTML5 client.
 
-## Restrict access to specific ports
+## Secure your system -- restrict access to specific ports
 
-If your server is behind a firewall already -- such as running within your company or on an EC2 instance behind a Amazon Security Group -- and the firewall is enforcing the above restrictions, you don't a second firewall and can skip this section.
+Configuring IP firewalling is *essential for securing your installation*. By default, many services are reachable across the network. This allows BigBlueButton operate in clusters and private data center networks -- but it creates a significant attack surface, if your BigBlueButton server is publicly available on the internet.
 
-If your BigBlueButton server is publicly available on the internet, then, for increased security, you should restrict access only to the following needed ports:
+If your server is behind a firewall already -- such as running within your company or on an EC2 instance behind a Amazon Security Group -- and the firewall is enforcing the above restrictions, you don't need a second firewall and can skip this section.
+
+BigBlueButton comes with a [UFW](https://launchpad.net/ufw) based ruleset. It it can be applied on restart (c.f. [Automatically apply configuration changes on restart](#automatically-apply-configuration-changes-on-restart)) and restricts access only to the following needed ports:
 
 * TCP/IP port 22 for SSH
 * TCP/IP port 80 for HTTP
@@ -72,6 +74,8 @@ ufw --force enable
 ```
 
 These `ufw` firewall rules will be automatically re-applied on server reboot.
+
+Besides IP-based firewalling, web application firewalls such as [ModSecurity](https://modsecurity.org/)  provide additional security by checking requests to various web-based components.
 
 ## Extract the shared secret
 

--- a/_posts/2019-02-15-install.md
+++ b/_posts/2019-02-15-install.md
@@ -548,7 +548,7 @@ If this server is intended for production, you should
 
 * [Assign the server a hostname](#assign-a-hostname)
 * [Install a SSL certificate to support HTTPS](#configure-ssl-on-your-bigbluebutton-server)
-* [Restrict access to specific ports](/2.2/customize.html#restrict-access-to-specific-ports)
+* [Secure your system -- restrict access to specific ports](/2.2/customize.html#secure-your-system--restrict-access-to-specific-ports)
 * [Configure the server to work behind a firewall](/2.2/configure-firewall) (if needed)
 * [remove the API demos](/2.2/customize.html#remove-the-api-demos) (if you had them installed for testing)
 * [Set up a TURN server](/2.2/setup-turn-server.html) (if your server is on the Internet and you have users accessing it from behind restrictive firewalls)


### PR DESCRIPTION
@ffdixon my idea w.r.t to out discussion in https://groups.google.com/d/msgid/bigbluebutton-dev/77b77c24-32b3-b441-66ce-91d596615f55%40jluehr.de

I think there's still some work do be done. I'm somehow fine with the documents in 7be3f0f98ba6652fcafb177e1b000c0ddab6f888 - but c94078f166c36468e2427ce963b465151e4a4bd9 is somewhat confusing, still.

Some points of confusion ;-):
* Why are 7443/tcp, 1935/tcp used the NAT connection test, if they're not needed, in the UFW-setting?
* What is "Before doing these steps you need to have done XXX in the installation guide." relates to? Can we fix that reference?
* On a higher level, firewalling is covered in three different documentations. That confuses me a little.  It feels like _posts/2019-02-14-configure-firewall.md is the relevant place, but this document is missing some parts on UFW and IPv6.

I'd cool, if we could fiddle these details. 

Thanks your work help and work,
Greetz, yanosz