### PR TITLE
Add simple-log to the example configuration

### DIFF
--- a/_posts/2019-02-14-setup-turn-server.md
+++ b/_posts/2019-02-14-setup-turn-server.md
@@ -144,6 +144,9 @@ no-tlsv1_1
 # Log to a single filename (rather than new log files each startup). You'll
 # want to install a logrotate configuration (see below)
 log-file=/var/log/coturn.log
+
+# To enable single filename logs you need to enable the simple-log flag
+simple-log
 ```
 
 ## Configure Log Rotation


### PR DESCRIPTION
My turn server always failed because without the simple-log flag it was not able to create the log files correctly.