### PR TITLE
Update 2019-02-14-customize.md

### DIFF
--- a/_posts/2019-02-14-customize.md
+++ b/_posts/2019-02-14-customize.md
@@ -484,6 +484,7 @@ echo "  - Update TURN server configuration turn-stun-servers.xml"
         </property>
     </bean>
 </beans>
+HERE
 ```
 
 ### Always record every meeting


### PR DESCRIPTION
the cat end of file indicator was missing and thus was using the whole file after "cat << HERE > ..."