### PR TITLE
Update 2020-05-09-privacy.md

### DIFF
--- a/_posts/2020-05-09-privacy.md
+++ b/_posts/2020-05-09-privacy.md
@@ -270,12 +270,38 @@ coturn has no option of restricting logging. The best option here is linking
 
 ## Logs
 
+### Nginx logs
 Scalelite uses a container running nginx as frontend, which accumulates standard access logs. By default scalelite has full access logs enabled for nginx. This includes users IP addresses, usernames, joined meetings, watched meetings etc. The easiest way to address this is migrating the nginx to the host, thus getting rid of Docker. 
 
 Then the logging can be disable by switching the loglevel to 'ERROR' in `/etc/nginx/sites-available/bigbluebutton` and `/etc/nginx/nginx.conf`:
 
 `error_log /var/log/nginx/bigbluebutton.error.log;`  
 `access_log /dev/null;`  
+
+### Scalelite-API-Container logs
+
+The container of the scalelite-API-Image (blindsidenetwks/scalelite:v1-api) is also logging user activities. For example:
+Who joined which meeting:
+
+`{"log":"I, [<timestamp>]  INFO -- : [<some_identifier>] Redirected to https://<URL>/bigbluebutton/api/join?meetingID=<meeting_ID>\u0026fullName=<name>\u0026password=<hashed_pw>... }`
+
+
+This logfile will never be deleted automatically and it will get quite large, if scalelite is serving many users.
+
+#### Resolution
+##### Delete via cronjob 
+This is a simple solution and works just fine, if there is only scalelite-containers on the host.
+as root:
+
+`crontab -e`
+
+and add:
+
+`0 3 * * 0,4 truncate -s 0 /var/lib/docker/containers/*/*-json.log `
+
+Care, this will delete all Docker-Container-Logfiles. At 03:00 every sunday and thursday.
+
+
 
 # General GDPR Considerations
 


### PR DESCRIPTION
mentioned scalelite-api-container logging and suggested a simple solution.