### PR TITLE
Add new installation method for larger deployments

### DIFF
--- a/_posts/2019-02-15-install.md
+++ b/_posts/2019-02-15-install.md
@@ -58,7 +58,7 @@ If you're looking to deploy a large-scale installation of BBB using [Scalelite](
 * automate to the fullest: by automating the process, you inherently save time on nasty troubleshooting and hours lost in manual configuration
 * easily scale at large: spin up an identical replica of your BBB server in less than 15 mins with no user input -- preconfigured and ready to go
 
-Choose this method if you are already comfortable with BigBlueButton, Scalelite and Greenlight/other front-ends. Refer to the following examples to create your installation:
+Choose this method if you are already comfortable with a lot of the technical knowledge behind BigBlueButton, Scalelite and Greenlight/other front-ends. Refer to the following examples to create your installation:
 
 Note: these are not maintained or developed by the official BigBlueButton developers. These are entirely community-sourced, use at your own discretion.
 

--- a/_posts/2019-02-15-install.md
+++ b/_posts/2019-02-15-install.md
@@ -19,17 +19,17 @@ BigBlueButton is not your average web application.  It's a fully responsive sing
 
 ## Full HTML5 client
 
-BigBlueButton uses a full HTML5 client for it's interface.  This means the same client runs on desktop, laptop, chromebook, and your mobile devices (iOS 12.2+ and Android 6.0+).  We recommend Chrome and FireFox as these browsers provide the best support for webRTC.
+BigBlueButton uses a full HTML5 client for it's interface.  This means the same client runs on desktop, laptop, chromebook, and your mobile devices (iOS 12.2+ and Android 6.0+).  We recommend Chrome and FireFox as these browsers provide the best support for WebRTC.
 
-The BigBlueButton client offers 
+The BigBlueButton client offers:
 
 * 2x faster loading than the previous version
 * High-quality audio, video, and screen sharing (using WebRTC)
 * Shared notes for multi-user editing (using the excellent [EtherPad](https://etherpad.org/) project)
 * Fully accessible to screen readers
-* Share YouTube videos during the session
+* Share videos from various providers (YouTube, Twitch, etc.) during the session
 
-You can try the latest version of the HTML5 client on [https://test.bigbluebutton.org/](https://test.bigbluebutton.org/).
+You can try the latest version of the HTML5 client at [https://test.bigbluebutton.org/](https://test.bigbluebutton.org/).
 
 ## Installation choices
 

--- a/_posts/2019-02-15-install.md
+++ b/_posts/2019-02-15-install.md
@@ -33,7 +33,7 @@ You can try the latest version of the HTML5 client at [https://test.bigbluebutto
 
 ## Installation choices
 
-When installing BigBlueButton you have two choices: `bbb-install.sh` and step-by-step.
+When installing BigBlueButton you have three choices: `bbb-install.sh`, Ansible (for large scale deployments) and step-by-step.
 
 Regardless of which choice you make, to have a successful installation you need to
 
@@ -42,11 +42,36 @@ Regardless of which choice you make, to have a successful installation you need 
 * assign a hostname (recommended to set up SSL), and
 * configure the server's firewall (if needed).
 
-The two choices are covered below.
+The three choices are covered below.
 
 ### bbb-install.sh
 
 If you want to set up a BigBlueButton server quickly (or have already setup BigBlueButton servers in the past), then [bbb-install.sh](https://github.com/bigbluebutton/bbb-install) will get you up and running with a single command in about 15 minutes.
+
+### Ansible
+
+If you're looking to deploy a large-scale installation of BBB using [Scalelite](https://github.com/blindsidenetworks/scalelite) then your servers are best managed using tools like Ansible. A few reasons you might go with this setup are:
+
+* easily customizable: your custom configurations will get replaced every time you upgrade automatically
+* parity across machines: ensure that you deploy the exact same version of BBB on every server
+* eliminate human error in setup: using bbb-install.sh or step-by-step methods are highly prone to human error as you can easily forget if you enabled a setting, chose to do X over Y, etc
+* automate to the fullest: by automating the process, you inherently save time on nasty troubleshooting and hours lost in manual configuration
+* easily scale at large: spin up an identical replica of your BBB server in less than 15 mins with no user input -- preconfigured and ready to go
+
+Choose this method if you are already comfortable with BigBlueButton, Scalelite and Greenlight/other front-ends. Refer to the following examples to create your installation:
+
+Note: these are not maintained or developed by the official BigBlueButton developers. These are entirely community-sourced, use at your own discretion.
+
+These first two install BigBlueButton on your server in a consistent fashion. You can specify variables, such as whether to install Greenlight too, what ports to use for TURN, and others. Functionally quite similar to bbb-install.sh but highly automated.
+
+* [General Ansible role for BigBlueButton](https://github.com/n0emis/ansible-role-bigbluebutton)
+* [Alternative Ansible role for BigBlueButton](https://github.com/juanluisbaptiste/ansible-bigbluebutton)
+
+Large scale deployments must include several other components in addition to the core BigBlueButton packages. These include Scalelite, Greenlight, a database, backups, nginx configurations, and more.
+
+* [Full out-of-the-box setup with wiki, chat, backups](https://github.com/stadtulm/a13-ansible)
+* [Full out-of-the-box setup with frontend on one machine](https://github.com/srcf/timeout) 
+* [Full setup for a university](https://github.com/unistra/bigbluebutton/)
 
 ### Step-by-step
 


### PR DESCRIPTION
Increasingly, a greater proportion of users want to deploy BigBlueButton on a large scale. Existing methods are not suitable for this for reasons stated in the PR. This adds a third valuable installation method using Ansible to mitigate the lack of documentation on this (Scalelite is quite recent) by combining several community-sourced projects in one location for reference.

It also makes sure existing information is accurate, eg. video types with ReactPlayer