### PR TITLE
Reshuffle entries in "Troubleshoot" for clarity

### DIFF
--- a/_posts/2019-02-14-customize.md
+++ b/_posts/2019-02-14-customize.md
@@ -75,7 +75,11 @@ for eventsfile in /var/bigbluebutton/recording/raw/*/events.xml ; do
 done
 ```
 
-Change the value for `MAXAGE` to specify how many days to retain the `presentation` format recordings on your BigBlueButton server.
+Change the value for `MAXAGE` to specify how many days to retain the `presentation` format recordings on your BigBlueButton server. After you create the file, make sure it is executable.
+
+```powershell
+$ chmod +x /etc/cron.daily/etc/cron.daily/delete-old-recordings
+```
 
 ### Move recordings to a different partition
 

--- a/_posts/2019-02-14-customize.md
+++ b/_posts/2019-02-14-customize.md
@@ -535,6 +535,73 @@ Then restart BigBlueButton
 $ sudo bbb-conf --restart
 ```
 
+## Connect BigBlueButton to an external FreeSWITCH Server
+
+BigBlueButton bundles in FreeSWITCH, but you can configure BigBlueButton to use an external FreeSWITCH server.
+
+First, edit `/usr/share/red5/webapps/bigbluebutton/WEB-INF/bigbluebutton.properties`
+
+```properties
+freeswitch.esl.host=127.0.0.1
+freeswitch.esl.port=8021
+freeswitch.esl.password=ClueCon
+```
+
+Change `freeswitch.esl.host` to point to your external FreeSWITCH IP address. Change the default `freeswitch.esl.password` to the ESL password for your server.
+
+You can use http://strongpasswordgenerator.com/ to generate passwords.
+
+In your external FreeSWITCH server, edit `/opt/freeswitch/conf/autoload_configs/event_socket.conf.xml`.
+
+```xml
+<configuration name="event_socket.conf" description="Socket Client">
+  <settings>
+    <param name="nat-map" value="false"/>
+    <param name="listen-ip" value="127.0.0.1"/>
+    <param name="listen-port" value="8021"/>
+    <param name="password" value="ClueCon"/>
+    <!-- param name="apply-inbound-acl" value="localnet.auto"/ -->
+  </settings>
+</configuration>
+```
+
+Change the `listen-ip` to your external FreeSWITCH server IP and also change the `password` to be the same as `freeswitch.esl.password`.
+
+Edit `/usr/share/red5/webapps/sip/WEB-INF/bigbluebutton-sip.properties`
+
+```properties
+bbb.sip.app.ip=127.0.0.1
+bbb.sip.app.port=5070
+
+sip.server.username=bbbuser
+sip.server.password=secret
+
+freeswitch.ip=127.0.0.1
+freeswitch.port=5060
+```
+
+Change `bbb.sip.app.ip` to your BigBlueButton server ip.
+
+Change `sip.server.password` to something else.
+
+Change `freeswitch.ip` to your external FreeSWITCH ip.
+
+In your external FreeSWITCH server.
+
+Edit `/opt/freeswitch/conf/directory/default/bbbuser.xml`
+
+```xml
+  <user id="bbbuser">
+    <params>
+      <!-- omit password for authless registration -->
+      <param name="password" value="secret"/>
+      <!-- What this user is allowed to access -->
+      <!--<param name="http-allowed-api" value="jsapi,voicemail,status"/> -->
+    </params>
+```
+
+Change `password` to match the password you set in `sip.server.password`.
+
 ## Presentation
 
 ### Change the default presentation

--- a/_posts/2019-02-14-troubleshooting.md
+++ b/_posts/2019-02-14-troubleshooting.md
@@ -74,14 +74,14 @@ For issues that may be network related -- such as users unable to share their au
 3. Does the server have a static or dynamic IP?
 4. Does the server IPV4 and/or IPV6 address?
 
-For issues that may be client related -- such as the client screen goes blue or unexpectedly becomes disconnected -- also include: 
+For issues that may be client related -- such as the client screen goes blue or unexpectedly becomes disconnected -- also include:
 
 1. Are you able to reproduce the issue on [https://demo.bigbluebutton.org/](https://demo.bigbluebutton.org/)?
 2. What browser and OS are you using?  (include the version of both)?
 3. If your testing from the desktop or laptop, does the problem occur in both FireFox and Chrome?
 4. Are there any errors in your browser's console?
 
-If you have multiple questions about the same server, you do not have to include the above information each time, just provide a URL to a previous post that covers this information.    
+If you have multiple questions about the same server, you do not have to include the above information each time, just provide a URL to a previous post that covers this information.
 
 There are many members of the BigBlueButton community that have been using and supporting BigBlueButton for years.  By including as much information as you can about your problem, you'll make it easier for them to volunteer their time to help you solve it quickly.
 
@@ -177,7 +177,7 @@ $ chmod +x /etc/cron.daily/etc/cron.daily/delete-old-recordings
 
 If after updating from BigBlueButton 2.0 to BigBlueButton 2.2 your recordings are not processing, and if you are seeing `Permission denied` errors in `/var/log/bigbluebutton/bbb-rap-worker.log`
 
-```
+```log
 I, [2019-06-07T14:26:09.034878 #14808]  INFO -- : /usr/lib/ruby/2.5.0/logger.rb:754:in `initialize': Permission denied @ rb_sysopen - /var/log/bigbluebutton/presentation/process-02feca80700b3e95b877af85db972904397857a1-1559909318977.log (Errno::EACCES)
 ```
 
@@ -222,7 +222,7 @@ Save the file and restart.
 
 If `sudo bbb-conf --check` returns the warning
 
-```
+```bash
 Restarting BigBlueButton 2.0.0-RC9 (and cleaning out all log files) ...
 Stopping BigBlueButton
  ... cleaning log files
@@ -277,7 +277,7 @@ In rare occasions after shutdown/restart, the FreeSWITCH database can get corrup
 
 To check, look in `/opt/freeswitch/var/log/freeswitch/freeswitch.log` for errors related to loading the database.
 
-```
+```log
 2018-10-25 11:05:11.444727 [ERR] switch_core_db.c:108 SQL ERR [unsupported file format]
 2018-10-25 11:05:11.444737 [ERR] switch_core_db.c:223 SQL ERR [unsupported file format]
 2018-10-25 11:05:11.444759 [NOTICE] sofia.c:5949 Started Profile internal-ipv6 [sofia_reg_internal-ipv6]
@@ -297,12 +297,12 @@ $ sudo systemctl start freeswitch
 
 Let's assume the following:
 
-```
+```bash
 asterisk server ip:          192.168.1.100
 bigbluebutton/freeswitch ip: 192.168.1.200
 ```
 
-**Changes to your Asterisk server**
+#### Changes to your Asterisk server
 
 Setup your gateway to BigBlueButton/FreeSWITCH. in `/etc/asterisk/sip.conf` add
 
@@ -322,12 +322,12 @@ allow=ulaw
 
 Route the calls to the gateway. In `/etc/asterisk/extensions.conf` context where your calls are being handled, forward the calls to the gateway. Here, when someone dials 85001, the call is sent to the `fs-gw` defined above.
 
-```
+```conf
 exten => 85001,1,Dial(SIP/fs-gw/${EXTEN})
 exten => 85001,2,Hangup
 ```
 
-**Changes to your BigBlueButton/FreeSWITCH server**
+#### Changes to your BigBlueButton/FreeSWITCH server
 
 In BigBlueButton/FreeSWITCH, make the following changes:
 
@@ -368,7 +368,7 @@ $ ./fs_cli
 
 FreeSWITCH supports both IPV4 and IPV6.  However, if your server does not support IPV6, FreeSWITCH will be unable to bind to port 8021.  If you run `sudo bbb-conf --check` and see the following error
 
-```
+```bash
 # Error: Found text in freeswitch.log:
 #
 #    Thread ended for mod_event_socket
@@ -449,7 +449,7 @@ Then do `systemctl daemon-reload` and restart BigBlueButton.  FreeSWITCH should 
 
 When doing `sudo bbb-conf --check`, you may see the warning
 
-```
+```bash
 voice Application failed to register with sip server
 ```
 
@@ -470,7 +470,7 @@ $ netstat -ant | grep 5060
 
 You should see an output such as
 
-```
+```bash
 tcp        0      0 234.147.116.3:5060    0.0.0.0:*               LISTEN
 ```
 
@@ -499,7 +499,7 @@ Alternatively, if you have not made any customizations to BigBlueButton (outside
 
 If you've installed/uninstalled BigBlueButton packages, you may get a `No Symbolic Link` warning from `bbb-conf --check`:
 
-```
+```bash
 ** Potential Problems **
     nginx (conf): no symbolic link in /etc/nginx/sites-enabled for bigbluebutton
 ```
@@ -515,7 +515,7 @@ $ sudo /etc/init.d/nginx restart
 
 Some of the BigBlueButton packages use `sed` scripts to extract contents from configuration files.  If the file does not exist at the time of the script's execution, or the sed script matches multiple entries in a file (such as when a configuration line is commented out), you can see an error such as
 
-```
+```bash
 Setting up bbb-client (1:2.0.0-374) ...
 sed: -e expression #1, char 42: unterminated `s' command
 dpkg: error processing package bbb-client (--configure):
@@ -546,7 +546,7 @@ You should now see each command in `bbb-conf.postinst` as it executes upto the l
 
 Some hosting providers do not provide a complete `/etc/apt/source.list`.  If you are finding your are unable to install a package, try replacing your `/etc/apt/sources.list` with the following
 
-```
+```bash
 deb http://archive.ubuntu.com/ubuntu xenial main restricted universe multiverse
 deb http://archive.ubuntu.com/ubuntu xenial-updates main restricted universe multiverse
 deb http://security.ubuntu.com/ubuntu xenial-security main restricted universe multiverse
@@ -576,7 +576,7 @@ Here are the following lists the possible WebRTC error messages that a user may 
 * **1003: Browser version not supported** - Browser doesn’t implement the necessary WebRTC API methods.  Possible Causes:
   * Out of date browser
 * **1004: Failure on call** - The call was attempted, but failed.  Possible Causes:
-  * For a full list of causes refer here, http://sipjs.com/api/0.6.0/causes/
+  * For a full list of causes refer [here](http://sipjs.com/api/0.6.0/causes/)
   * There are 24 different causes so I don’t really want to list all of them
   * Solution for this issue [outlined here](https://groups.google.com/forum/#!msg/bigbluebutton-setup/F2MlW6Voj-0/ZXDq5_-uEQAJ).
 * **1005: Call ended unexpectedly** - The call was successful, but ended without user requesting to end the session.  Possible Causes:
@@ -611,7 +611,7 @@ To enable Chrome to access the user's microphone, see [Configure HTTPS on BigBlu
 
 When you attempt to join a BigBlueButton session, the client looks for supported browsers before fully loading.  The client gets its list of supported browsers from `/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml`.  You can see the list of supported browsers at the bottom.  For example,
 
-```
+```yaml
   - browser: mobileSafari
     version:
     - 11
@@ -622,13 +622,13 @@ states that `Mobile Safari` version 11.1 or later is supported (notice the first
 
 To add a browser to the list, first open the following page [https://demo.bigbluebutton.org/html5client/useragent](https://demo.bigbluebutton.org/html5client/useragent) with the browser, which will print its useragent string.  For example, with the Vivaldi browser you might see
 
-```
+```log
 Vivaldi 2.8.1664 / Linux 0.0.0
 ```
 
 Next, to add this as a supported browser, append to `settings.yml`
 
-```
+```yaml
   - browser: vivaldi
     version:
     - 2
@@ -643,7 +643,7 @@ If your server has multiple IP addresses, Tomcat might not pick the right addres
 
 Check `/var/log/tomcat7/catalina.out` for the following error
 
-```
+```log
 Jan 30, 2018 9:17:37 AM org.apache.catalina.core.StandardServer await
 SEVERE: StandardServer.await: create[localhost:8005]:
 java.net.BindException: Cannot assign requested address (Bind failed)
@@ -682,7 +682,7 @@ $ sudo systemctl restart nginx
 
 and look for the output of
 
-```
+```log
    [ OK ]
 ```
 
@@ -712,7 +712,7 @@ BigBlueButton 2.2 requires Java 8 as the default Java.  Recently, some Ubuntu 16
 
 Use `java -version` to check that the default version of `1.8.0`.
 
-```
+```bash
 ~/dev$ java -version
 openjdk version "1.8.0_242"
 OpenJDK Runtime Environment (build 1.8.0_242-8u242-b08-0ubuntu3~16.04-b08)
@@ -721,7 +721,7 @@ OpenJDK 64-Bit Server VM (build 25.242-b08, mixed mode)
 
 If not, do the following
 
-```
+```bash
 sudo apt-get install openjdk-8-jre
 update-alternatives --config java  # Choose java-8 as default
 ```
@@ -732,22 +732,23 @@ Run `java -version` and confirm it now shows the default as `1.8.0`, and then re
 
 If you see the following error in `/var/log/bigbluebutton/bbb-web.log`
 
-```
+```log
   failed to map segment from shared object: Operation not permitted
 ```
 
 use the command `mount` to check that the `/tmp` director does not have `noexec` permissions (which would prevent executables from running in the /tmp directory). If you see `noexec` for `/tmp`, you need to remount the directory with permissions that enable processes (such as the slide conversion) to execute in the `/tmp` directory.
 
-### Too many open files 
+### Too many open files
+
 On servers with greater than 8 CPU cores, `bbb-web` log (`/var/log/bigbluebutton/bbb-web.log`) may throw an error of `Too many open files`
 
-~~~log
+```log
 Caused by: java.io.IOException: Too many open files
-~~~
+```
 
 To resolve, create an override file that increases the number of open files for `bbb-web`
 
-~~~bash
+```bash
 $  sudo mkdir -p /etc/systemd/system/bbb-web.service.d/
 $  sudo cat > /etc/systemd/system/bbb-web.service.d/override.conf << HERE
 [Service]
@@ -755,7 +756,7 @@ LimitNOFILE=
 LimitNOFILE=8192
 HERE
 $  sudo systemctl daemon-reload
-~~~
+```
 
 ### bbb-web takes a long time to startup
 
@@ -773,7 +774,7 @@ For more information see [How to Setup Additional Entropy for Cloud Servers Usin
 
 If you get the following error during upgrade to BigBlueButton
 
-```
+```bash
 Unpacking bbb-web (1:2.2.0-67) over (1:2.2.0-66) ...
 dpkg: error processing archive /var/cache/apt/archives/bbb-web_1%3a2.2.0-67_amd64.deb (--unpack):
  trying to overwrite '/etc/bigbluebutton/nginx/web', which is also in package bbb-client 1:2.2.0-28
@@ -839,7 +840,7 @@ For more information see [bbb-conf options](/install/bbb-conf.html).
 
 However, if you install BigBlueButton within an LXD container, you will get the following error from `sudo bbb-conf --check`
 
-```
+```bash
 ** Potential problems described below **
 
 #
@@ -902,10 +903,9 @@ You can run BigBlueButton within a LXD container.
 
 The command `sudo bbb-conf --debug` searches through the red5, tomcat7, and nginx logs looking for errors and exceptions.  However, the messages such as
 
-```
+```log
     -- ERRORS found in /usr/share/red5/log/* --
 /usr/share/red5/log/bigbluebutton.log:2015-05-02 13:50:37,681-04:00 [pool-17-thread-1] ERROR o.b.w.v.f.a.PopulateRoomCommand - Not XML: [Conference 78505 not found]
 ```
 
 are innocuous and can be ignored.
-

--- a/_posts/2019-02-14-troubleshooting.md
+++ b/_posts/2019-02-14-troubleshooting.md
@@ -285,11 +285,13 @@ Here are the following lists the possible WebRTC error messages that a user may 
 * **1002: Could not make a WebSocket connection** - The initial WebSocket connection was unsuccessful.  Possible Causes:
   * Firewall blocking ws protocol
   * Server is down or improperly configured
+  * See potential solution [here](https://github.com/bigbluebutton/bigbluebutton/issues/2628).
 * **1003: Browser version not supported** - Browser doesn’t implement the necessary WebRTC API methods.  Possible Causes:
   * Out of date browser
 * **1004: Failure on call** - The call was attempted, but failed.  Possible Causes:
   * For a full list of causes refer here, http://sipjs.com/api/0.6.0/causes/
   * There are 24 different causes so I don’t really want to list all of them
+  * Solution for this issue [outlined here](https://groups.google.com/forum/#!msg/bigbluebutton-setup/F2MlW6Voj-0/ZXDq5_-uEQAJ).
 * **1005: Call ended unexpectedly** - The call was successful, but ended without user requesting to end the session.  Possible Causes:
   * Unknown
 * **1006: Call timed out** - The library took too long to try and connect the call.  Possible Causes:
@@ -300,6 +302,7 @@ Here are the following lists the possible WebRTC error messages that a user may 
 * **1008: Call transfer failed** - A timeout while waiting for FreeSWITCH to transfer from the echo test to the real conference. This might be caused by a misconfiguration in FreeSWITCH, or there might be a media error and the DTMF command to transfer didn't go through (In this case, the voice in the echo test probably didn't work either.)
 * **1009: Could not fetch STUN/TURN server information** - This indicates either a BigBlueButton bug (or you're using an unsupported new client/old server combination), but could also happen due to a network interruption.
 * **1010: ICE negotiation timeout** - After the call is accepted the client's browser and the server try and negotiate a path for the audio data. In some network setups this negotiation takes an abnormally long time to fail and this timeout is set to avoid the client getting stuck.
+* **1020: Media cloud could not reach the server** - See how to solve this [here](https://github.com/bigbluebutton/bigbluebutton/issues/6797#issuecomment-607866043).
 
 ## Not running: nginx
 
@@ -650,73 +653,6 @@ If you still see the same error in `catalina.out`, then `/etc/tomcat7/server.xml
 
 Restart tomcat7 again and it should start normally.
 
-## Connect BigBlueButton to an external FreeSWITCH Server
-
-BigBlueButton bundles in FreeSWITCH, but you can configure BigBlueButton to use an external FreeSWITCH server.
-
-First, edit `/usr/share/red5/webapps/bigbluebutton/WEB-INF/bigbluebutton.properties`
-
-```properties
-freeswitch.esl.host=127.0.0.1
-freeswitch.esl.port=8021
-freeswitch.esl.password=ClueCon
-```
-
-Change `freeswitch.esl.host` to point to your external FreeSWITCH IP address. Change the default `freeswitch.esl.password` to the ESL password for your server.
-
-You can use http://strongpasswordgenerator.com/ to generate passwords.
-
-In your external FreeSWITCH server, edit `/opt/freeswitch/conf/autoload_configs/event_socket.conf.xml`.
-
-```xml
-<configuration name="event_socket.conf" description="Socket Client">
-  <settings>
-    <param name="nat-map" value="false"/>
-    <param name="listen-ip" value="127.0.0.1"/>
-    <param name="listen-port" value="8021"/>
-    <param name="password" value="ClueCon"/>
-    <!-- param name="apply-inbound-acl" value="localnet.auto"/ -->
-  </settings>
-</configuration>
-```
-
-Change the `listen-ip` to your external FreeSWITCH server IP and also change the `password` to be the same as `freeswitch.esl.password`.
-
-Edit `/usr/share/red5/webapps/sip/WEB-INF/bigbluebutton-sip.properties`
-
-```properties
-bbb.sip.app.ip=127.0.0.1
-bbb.sip.app.port=5070
-
-sip.server.username=bbbuser
-sip.server.password=secret
-
-freeswitch.ip=127.0.0.1
-freeswitch.port=5060
-```
-
-Change `bbb.sip.app.ip` to your BigBlueButton server ip.
-
-Change `sip.server.password` to something else.
-
-Change `freeswitch.ip` to your external FreeSWITCH ip.
-
-In your external FreeSWITCH server.
-
-Edit `/opt/freeswitch/conf/directory/default/bbbuser.xml`
-
-```xml
-  <user id="bbbuser">
-    <params>
-      <!-- omit password for authless registration -->
-      <param name="password" value="secret"/>
-      <!-- What this user is allowed to access -->
-      <!--<param name="http-allowed-api" value="jsapi,voicemail,status"/> -->
-    </params>
-```
-
-Change `password` to match the password you set in `sip.server.password`.
-
 ## WebRTC video not working with Kurento
 
 Check the value for `/proc/sys/net/ipv4/tcp_syncookies` that it contains the value `1`.
@@ -966,3 +902,6 @@ HERE
 $  sudo systemctl daemon-reload
 ~~~
 
+## Server running behind NAT
+
+The [following issue](https://github.com/bigbluebutton/bigbluebutton/issues/8792) might be helpful in debugging if you run into errors and your server is behind NAT.

--- a/_posts/2019-02-14-troubleshooting.md
+++ b/_posts/2019-02-14-troubleshooting.md
@@ -105,9 +105,75 @@ For development and contributions, use the issue tracker on the GitHub repositor
 
 This section will help you resolve common errors with installation and configuration of BigBlueButton server.
 
-If you have not already done so, read through the [installation section](#i-have-a-problem-setting-up-bigbluebutton) on getting help.
+If you have not already done so, read through the [getting help section](/2.2/getting-started.html).
 
-## Recording not processing after upgrading
+## Introduction
+
+**Start here:** run `sudo bbb-conf --check`
+
+We've built in a BigBlueButton configuration utility, called `bbb-conf`, to help you configure your BigBlueButton server and troubleshoot your setup if something doesn't work right.
+
+If you think something isn't working correctly, the first step is enter the following command.
+
+```bash
+$ sudo bbb-conf --check
+```
+
+This will check your setup to ensure the correct processes are running, the BigBlueButton components have correctly started, and look for common configuration problems that might prevent BigBlueButton from working properly.
+
+If you see text after the line `** Potential problems described below **`, then it may be warnings (which you can ignore if you've change settings) or errors with the setup.
+
+## Recording
+
+### Delete recordings older than N days
+
+You may want to not keep recordings that are older than N days.  Add the following script to `/etc/cron.daily/delete-old-recordings`:
+
+```bash
+#!/bin/bash
+
+MAXAGE=7
+
+LOGFILE=/var/log/bigbluebutton/bbb-recording-cleanup.log
+
+shopt -s nullglob
+
+NOW=$(date +%s)
+
+echo "$(date --rfc-3339=seconds) Deleting recordings older than ${MAXAGE} days" >>"${LOGFILE}"
+
+for donefile in /var/bigbluebutton/recording/status/published/*-presentation.done ; do
+        MTIME=$(stat -c %Y "${donefile}")
+        # Check the age of the recording
+        if [ $(( ( $NOW - $MTIME ) / 86400 )) -gt $MAXAGE ]; then
+                MEETING_ID=$(basename "${donefile}")
+                MEETING_ID=${MEETING_ID%-presentation.done}
+                echo "${MEETING_ID}" >> "${LOGFILE}"
+
+                bbb-record --delete "${MEETING_ID}" >>"${LOGFILE}"
+        fi
+done
+
+for eventsfile in /var/bigbluebutton/recording/raw/*/events.xml ; do
+        MTIME=$(stat -c %Y "${eventsfile}")
+        # Check the age of the recording
+        if [ $(( ( $NOW - $MTIME ) / 86400 )) -gt $MAXAGE ]; then
+                MEETING_ID="${eventsfile%/events.xml}"
+                MEETING_ID="${MEETING_ID##*/}"
+                echo "${MEETING_ID}" >> "${LOGFILE}"
+
+                bbb-record --delete "${MEETING_ID}" >>"${LOGFILE}"
+        fi
+done
+```
+
+You can modify length your server will retain recordings by changing `MAXAGE=7` to a different number.  After you create the file, make sure it is executable.
+
+```powershell
+$ chmod +x /etc/cron.daily/etc/cron.daily/delete-old-recordings
+```
+
+### Recording not processing after upgrading
 
 If after updating from BigBlueButton 2.0 to BigBlueButton 2.2 your recordings are not processing, and if you are seeing `Permission denied` errors in `/var/log/bigbluebutton/bbb-rap-worker.log`
 
@@ -133,348 +199,101 @@ and then to rebuild a recording, use `sudo bbb-record --rebuild <internal_meetin
 $ sudo bbb-record --rebuild 298b06603719217df51c5d030b6e9417cc036476-1559314745219
 ```
 
-## Run sudo bbb-conf --check
+## Kurento
 
-We've built in a BigBlueButton configuration utility, called `bbb-conf`, to help you configure your BigBlueButton server and troubleshoot your setup if something doesn't work right.
+### WebRTC video not working with Kurento
 
-If you think something isn't working correctly, the first step is enter the following command.
-
-```bash
-$ sudo bbb-conf --check
-```
-
-This will check your setup to ensure the correct processes are running, the BigBlueButton components have correctly started, and look for common configuration problems that might prevent BigBlueButton from working properly.
-
-If you see text after the line `** Potential problems described below **`, then it may be warnings (which you can ignore if you've change settings) or errors with the setup.
-
-## Could not get your microphone for a WebRTC call
-
-Chrome requires (As of Chrome 47) that to access the user's microphone for WebRTC your site must be serving pages via HTTPS (that is, nginx is configured with a SSL certificate).
-
-If the user attempts to share their microphone and your BigBlueButton sever is not configured for SSL, Chrome will block access and BigBlueButton will report the following error
-
-   _WebRTC Audio Failure: Detected the following WebRTC issue: Could not get your microphone for a WebRTC call. Do you want to try flash instead?_
-
-To enable Chrome to access the user's microphone, see [Configure HTTPS on BigBlueButton](/2.2/install.html#configure-ssl-on-your-bigbluebutton-server).
-
-## bbb-web takes a long time to startup
-
- `bbb-web` relies on the SecureRandom class (which uses available entropy) to provide random values for its session IDs.  On a virtualized server, however, the available entropy can run low and cause bbb-web to block for a long period before it finishes it's startup sequence (see [Slow startup of tomcat](https://stackoverflow.com/questions/28201794/slow-startup-on-tomcat-7-0-57-because-of-securerandom)).
-
-To provide `bbb-web` with more entropy, you can install haveged
+Check the value for `/proc/sys/net/ipv4/tcp_syncookies` that it contains the value `1`.
 
 ```bash
-$ sudo apt-get install haveged
+$ cat /proc/sys/net/ipv4/tcp_syncookies
+1
 ```
 
-For more information see [How to Setup Additional Entropy for Cloud Servers Using Haveged](https://www.digitalocean.com/community/tutorials/how-to-setup-additional-entropy-for-cloud-servers-using-haveged).
+If not, edit `/etc/sysctl.conf` and set the value for `net.ipv4.tcp_syncookies` to `1`.
 
-## Errors with packages
-
-Some hosting providers do not provide a complete `/etc/apt/source.list`.  If you are finding your are unable to install a package, try replacing your `/etc/apt/sources.list` with the following
-
-```
-deb http://archive.ubuntu.com/ubuntu xenial main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu xenial-updates main restricted universe multiverse
-deb http://security.ubuntu.com/ubuntu xenial-security main restricted universe multiverse
+```ini
+net.ipv4.tcp_syncookies = 1
 ```
 
-then do
+Save the file and restart.
+
+### Unit kurento-media-server.service is masked
+
+If `sudo bbb-conf --check` returns the warning
+
+```
+Restarting BigBlueButton 2.0.0-RC9 (and cleaning out all log files) ...
+Stopping BigBlueButton
+ ... cleaning log files
+Starting BigBlueButton
+Failed to start kurento-media-server.service: Unit kurento-media-server.service is masked.
+```
+
+You can unmask Kurento using the command
 
 ```bash
-$ sudo apt-get update
+$ systemctl unmask kurento-media-server.service
 ```
 
-and try installing BigBlueButton again from the beginning.
+## FreeSWITCH
 
-## Welcome to nginx
+### Configure BigBluebutton/FreeSWITCH to support IPV6
 
-During installation of BigBlueButton the packaging scripts attempt to assign the correct IP address during setup. However, if the IP address changes (such as when rebooting a VM), or the first IP address was not the correct IP address for the server, you may see a "Welcome to nginx" page.  
+The HTML5 client now enables users on mobile devices to connect to a BigBlueButton server.  However, on some cellular networks iOS devices only receive an IPV6 address.
 
-To reconfigure the BigBlueButton to use the correct IP address or hostname, see [BigBlueButton does not load](#bigbluebutton-does-not-load).
+To enable BigBlueButton (FreeSWITCH) to accept incoming web socket connections on IPV6, the BigBlueButton server must have an IPV6 address.  You also need to make the following changes to the server.
 
-## BigBlueButton does not load
+First, create the file `/etc/nginx/conf.d/bigbluebutton_sip_addr_map.conf` with this content:
 
-If your has changed it's network connection (such as on reboot), you can most of BigBlueButton's configuration files with the following steps.
+```nginx
+map $remote_addr $freeswitch_addr {
+    "~:"    [2001:db8::1];
+    default    192.0.2.1;
+}
+```
+
+replacing the ip addresses `192.0.2.1` with the system's external IPV4 addresses, and replace `2001:db8::1` with the system's external IPV6 address.  Next, edit the file `/etc/bigbluebutton/nginx/sip.nginx` to have the following:
+
+```nginx
+proxy_pass https://$freeswitch_addr:7443;
+```
+
+Next, ensure all of the following params are present in freeswitch's `sip_profiles/external-ipv6.xml`:
+
+* ws-binding
+* wss-binding
+* rtcp-audio-interval-msec
+* rtcp-video-interval-msec
+* dtmf-type
+* liberal-dtmf
+* enable-3pcc
+
+If any are missing, copy them from `sip_profiles/external.xml`, then restart BigBlueButton (`sudo bbb-conf --restart`).
+
+### FreeSWITCH fails to bind to IPV4
+
+In rare occasions after shutdown/restart, the FreeSWITCH database can get corrupted.  This will cause FreeSWITCH to have problems binding to IPV4 address (you may see error 1006 when users try to connect).  
+
+To check, look in `/opt/freeswitch/var/log/freeswitch/freeswitch.log` for errors related to loading the database.
+
+```
+2018-10-25 11:05:11.444727 [ERR] switch_core_db.c:108 SQL ERR [unsupported file format]
+2018-10-25 11:05:11.444737 [ERR] switch_core_db.c:223 SQL ERR [unsupported file format]
+2018-10-25 11:05:11.444759 [NOTICE] sofia.c:5949 Started Profile internal-ipv6 [sofia_reg_internal-ipv6]
+2018-10-25 11:05:11.444767 [CRIT] switch_core_sqldb.c:508 Failure to connect to CORE_DB sofia_reg_external!
+2018-10-25 11:05:11.444772 [CRIT] sofia.c:3049 Cannot Open SQL Database [external]!
+```
+
+If you see these errors, clear the FreeSWITCH database (BigBlueButton doesn't use the database and FreeSWITCH will recreate it on startup).
 
 ```bash
-$ sudo bbb-conf --setip <ip_address_or_hostname>
-
-$ sudo bbb-conf --clean
-$ sudo bbb-conf --check
+$ sudo systemctl stop freeswitch
+$ rm -rf /opt/freeswitch/var/lib/freeswitch/db/*
+$ sudo systemctl start freeswitch
 ```
 
-For more information see [bbb-conf options](/install/bbb-conf.html).
-
-## Conference not found errors
-
-The command `sudo bbb-conf --debug` searches through the red5, tomcat7, and nginx logs looking for errors and exceptions.  However, the messages such as
-
-```
-    -- ERRORS found in /usr/share/red5/log/* --
-/usr/share/red5/log/bigbluebutton.log:2015-05-02 13:50:37,681-04:00 [pool-17-thread-1] ERROR o.b.w.v.f.a.PopulateRoomCommand - Not XML: [Conference 78505 not found]
-```
-
-are innocuous and can be ignored.
-
-## No Symbolic Link
-
-If you've installed/uninstalled BigBlueButton packages, you may get a `No Symbolic Link` warning from `bbb-conf --check`:
-
-```
-** Potential Problems **
-    nginx (conf): no symbolic link in /etc/nginx/sites-enabled for bigbluebutton
-```
-
-To solve this,  add a symbolic link to nginx for the BigBlueButton site:
-
-```bash
-$ sudo ln -s /etc/nginx/sites-available/bigbluebutton /etc/nginx/sites-enabled/bigbluebutton
-$ sudo /etc/init.d/nginx restart
-```
-
-## Users not able to join Listen Only mode
-
-When doing `sudo bbb-conf --check`, you may see the warning
-
-```
-voice Application failed to register with sip server
-```
-
-This error occurs when `bbb-apps-sip` isn't able to make a SIP call to FreeSWITCH.  You'll see this in BigBlueButton when users click the headset icon and don't join the voice conference.
-
-One possible cause for this is you have just installed BigBlueButton, but not restarted it.  The packages do not start up the BigBlueButton components in the right order.  To restart BigBlueButton, do the following:
-
-```bash
-$ sudo bbb-conf --restart
-$ sudo bbb-conf --check
-```
-
-If you don't want FreeSWITCH to bind to 127.0.0.1, you need to figure out which IP address its using.  First, determine the IP address FreeSWITCH is monitoring for incoming SIP calls with the following command:
-
-```bash
-$ netstat -ant | grep 5060
-```
-
-You should see an output such as
-
-```
-tcp        0      0 234.147.116.3:5060    0.0.0.0:*               LISTEN
-```
-
-In this example, FreeSWITCH is listening on IP address 234.147.116.3.  The IP address on your server will be different.
-
-Next, edit `/usr/share/red5/webapps/sip/WEB-INF/bigbluebutton-sip.properties` and set the value for `sip.server.host` to the IP address returned from the above command.   Save the changes (you'll need to edit the file as root to save changes).
-
-Restart BigBlueButton using the commands and run the built-in diagnostics checks.
-
-```bash
-$ sudo bbb-conf --clean
-$ sudo bbb-conf --check
-```
-
-## Client WebRTC Error Codes
-
-WebRTC offers very high-quality audio.  However, the user's network settings (or firewall) may not allow WebRTC to connect (or keep connected).
-
-Here are the following lists the possible WebRTC error messages that a user may encounter:
-
-* **1001: WebSocket disconnected** - The WebSocket had connected successfully and has now disconnected.  Possible Causes:
-  * Loss of internet connection
-  * Nginx restarting can cause this
-* **1002: Could not make a WebSocket connection** - The initial WebSocket connection was unsuccessful.  Possible Causes:
-  * Firewall blocking ws protocol
-  * Server is down or improperly configured
-  * See potential solution [here](https://github.com/bigbluebutton/bigbluebutton/issues/2628).
-* **1003: Browser version not supported** - Browser doesn’t implement the necessary WebRTC API methods.  Possible Causes:
-  * Out of date browser
-* **1004: Failure on call** - The call was attempted, but failed.  Possible Causes:
-  * For a full list of causes refer here, http://sipjs.com/api/0.6.0/causes/
-  * There are 24 different causes so I don’t really want to list all of them
-  * Solution for this issue [outlined here](https://groups.google.com/forum/#!msg/bigbluebutton-setup/F2MlW6Voj-0/ZXDq5_-uEQAJ).
-* **1005: Call ended unexpectedly** - The call was successful, but ended without user requesting to end the session.  Possible Causes:
-  * Unknown
-* **1006: Call timed out** - The library took too long to try and connect the call.  Possible Causes:
-  * Previously caused by Firefox 33-beta on Mac.   We've been unable to reproduce since release of FireFox 34
-* **1007: ICE negotiation failed** - The browser and FreeSWITCH try to negotiate ports to use to stream the media and that negotiation failed.  Possible Causes:
-  * NAT is blocking the connection
-  * Firewall is blocking the UDP connection/ports
-* **1008: Call transfer failed** - A timeout while waiting for FreeSWITCH to transfer from the echo test to the real conference. This might be caused by a misconfiguration in FreeSWITCH, or there might be a media error and the DTMF command to transfer didn't go through (In this case, the voice in the echo test probably didn't work either.)
-* **1009: Could not fetch STUN/TURN server information** - This indicates either a BigBlueButton bug (or you're using an unsupported new client/old server combination), but could also happen due to a network interruption.
-* **1010: ICE negotiation timeout** - After the call is accepted the client's browser and the server try and negotiate a path for the audio data. In some network setups this negotiation takes an abnormally long time to fail and this timeout is set to avoid the client getting stuck.
-* **1020: Media cloud could not reach the server** - See how to solve this [here](https://github.com/bigbluebutton/bigbluebutton/issues/6797#issuecomment-607866043).
-
-## Not running: nginx
-
-The common reasons for nginx not running are inability to bind to port 80 and configuration errors.  To check if port 80 is already in use, use
-
-```bash
-$ sudo netstat -ant
-```
-
-to see if any process is currently bound to port 80.  If so, check to see if another web server is installed.  If so, then stop the web server and try to restart nginx.  One of the server requirements before you install BigBlueButton is that port 80 is not in use by another application (such as Apache).  For details on why this is a requirements, see [We recommend running BigBlueButton on port 80](http://docs.bigbluebutton.org/support/faq.html#we-recommend-running-bigbluebutton-on-port-80443).
-
-If port 80 is free, check if your nginx configuration file has errors.  Try a restart of nginx
-
-```bash
-$ sudo systemctl restart nginx
-```
-
-and look for the output of
-
-```
-   [ OK ]
-```
-
-If you see `[ Fail ]`, then your nginx configuration files might have a syntax error.  Check the syntax of the nginx configuration files using the command
-
-```bash
-$ sudo nginx -t
-```
-
-and see if it rerpots any errors.  You can also check the error.log file for nginx to see what errors it gives on startup
-
-```bash
-$ sudo cat /var/log/nginx/error.log
-```
-
-## Running within an LXD Container
-
-[LXD](https://www.ubuntu.com/containers/lxd) is a very powerful container system for Ubuntu lets you run full Ubuntu 16.04 servers within a container.  Because you can easily clone and snapshot LXD containers, they are ideal for development and testing of BigBlueButton.
-
-However, if you install BigBlueButton within an LXD container, you will get the following error from `sudo bbb-conf --check`
-
-```
-** Potential problems described below **
-
-#
-# Error: Unable to connect to the FreeSWITCH Event Socket Layer on port 8021
-```
-
-You'll also get an error from starting FreeSWITCH with `bbb-conf --restart`.  When you try `systemctl status freeswitch.service`, you'll see an error with SETSCHEDULER.
-
-```bash
-$ sudo systemctl status freeswitch.service
-● freeswitch.service - freeswitch
-   Loaded: loaded (/lib/systemd/system/freeswitch.service; enabled; vendor preset: enabled)
-   Active: inactive (dead) (Result: exit-code) since Wed 2017-04-26 16:34:24 UTC; 23h ago
-  Process: 7038 ExecStart=/opt/freeswitch/bin/freeswitch -u freeswitch -g daemon -ncwait $DAEMON_OPTS (code=exited, status=214/SETSCHEDULER)
-
-Apr 26 16:34:24 big systemd[1]: Failed to start freeswitch.
-Apr 26 16:34:24 big systemd[1]: freeswitch.service: Unit entered failed state.
-Apr 26 16:34:24 big systemd[1]: freeswitch.service: Failed with result 'exit-code'.
-Apr 26 16:34:24 big systemd[1]: freeswitch.service: Service hold-off time over, scheduling restart.
-Apr 26 16:34:24 big systemd[1]: Stopped freeswitch.
-Apr 26 16:34:24 big systemd[1]: freeswitch.service: Start request repeated too quickly.
-Apr 26 16:34:24 big systemd[1]: Failed to start freeswitch.
-```
-
-This error occurs because the default systemd unit script for FreeSWITCH tries to run with permissions not available to the LXD container.  To run FreeSWITCH within an LXD container, edit `/lib/systemd/system/freeswitch.service` and replace with the following
-
-```properties
-[Unit]
-Description=freeswitch
-After=syslog.target network.target local-fs.target
-
-[Service]
-Type=forking
-PIDFile=/opt/freeswitch/var/run/freeswitch/freeswitch.pid
-Environment="DAEMON_OPTS=-nonat"
-EnvironmentFile=-/etc/default/freeswitch
-ExecStart=/opt/freeswitch/bin/freeswitch -u freeswitch -g daemon -ncwait $DAEMON_OPTS
-TimeoutSec=45s
-Restart=always
-WorkingDirectory=/opt/freeswitch
-User=freeswitch
-Group=daemon
-
-[Install]
-WantedBy=multi-user.target
-```
-
-Then enter the following commands to load the new unit file and restart BigBlueButton.
-
-```bash
-$ sudo systemctl daemon-reload
-$ sudo bbb-conf --restart
-```
-
-You can run BigBlueButton within a LXD container.
-
-## Root partition too small
-
-If the root partition on your BigBlueButton server is too small (for disk space requirements see [Before you install](/2.2/install.html#before-you-install)), we recommend moving the following directories to an external partition with sufficient disk space.
-
-BigBlueButton processing and storage of recordings:
-
-```
-  /var/bigbluebutton
-```
-
-FreeSWITCH recording of audio files:
-
-```
-  /var/freeswitch/meetings
-```
-
-And red5 recording of video files:
-
-```
-  /usr/share/red5/webapps/video/streams
-```
-
-To make the move, we'll first stop BigBlueButton, then move the above directories to a new location on the external partition, create symbolic links from the original locations to the new locations, and restart BigBlueButton.  
-
-In the following example, the external partition is mounted on `/mnt`.
-
-```bash
-$ sudo bbb-conf --stop
-
-$ sudo mv /var/freeswitch/meetings /mnt
-$ sudo ln -s /mnt/recordings /var/freeswitch/meetings
-
-$ sudo mv /usr/share/red5/webapps/video/streams /mnt
-$ sudo ln -s /mnt/streams /usr/share/red5/webapps/video/streams
-
-$ sudo /var/bigbluebutton /mnt
-$ sudo ln -s /mnt/bigbluebutton /var/bigbluebutton
-
-$ sudo bbb-conf --start
-```
-
-## Error installing bbb-web
-
-If you get the following error during upgrade to BigBlueButton
-
-```
-Unpacking bbb-web (1:2.2.0-67) over (1:2.2.0-66) ...
-dpkg: error processing archive /var/cache/apt/archives/bbb-web_1%3a2.2.0-67_amd64.deb (--unpack):
- trying to overwrite '/etc/bigbluebutton/nginx/web', which is also in package bbb-client 1:2.2.0-28
-dpkg-deb: error: subprocess paste was killed by signal (Broken pipe)
-Errors were encountered while processing:
- /var/cache/apt/archives/bbb-web_1%3a2.2.0-67_amd64.deb
-E: Sub-process /usr/bin/dpkg returned an error code (1)```
-```
-
-Then first uninstall `bbb-client`
-
-```bash
-$ sudo apt-get purge bbb-client
-```
-
-and try installing BigBlueButton again.
-
-## Unable to create presentation
-
-If you see the following error in `/var/log/bigbluebutton/bbb-web.log`
-
-```
-  failed to map segment from shared object: Operation not permitted
-```
-
-use the command `mount` to check that the `/tmp` director does not have `noexec` permissions (which would prevent executables from running in the /tmp directory). If you see `noexec` for `/tmp`, you need to remount the directory with permissions that enable processes (such as the slide conversion) to execute in the `/tmp` directory.
-
-## Forward calls from an Asterisk server to FreeSWITCH
+### Forward calls from an Asterisk server to FreeSWITCH
 
 Let's assume the following:
 
@@ -545,7 +364,7 @@ $ ./fs_cli
   Ctrl-D to exit
 ```
 
-## FreeSWITCH fails to bind to port 8021
+### FreeSWITCH fails to bind to port 8021
 
 FreeSWITCH supports both IPV4 and IPV6.  However, if your server does not support IPV6, FreeSWITCH will be unable to bind to port 8021.  If you run `sudo bbb-conf --check` and see the following error
 
@@ -593,7 +412,7 @@ $ sudo bbb-conf --clean
 $ sudo bbb-conf --check
 ```
 
-## FreeSWITCH fails to start with a SETSCHEDULER error
+### FreeSWITCH fails to start with a SETSCHEDULER error
 
 When running in a container (like a chroot, OpenVZ or LXC), it might not be possible for FreeSWITCH to set the CPU priority and other tasks is not possible.
 
@@ -626,51 +445,73 @@ CPUSchedulingPriority=89
 
 Then do `systemctl daemon-reload` and restart BigBlueButton.  FreeSWITCH should now startup without error.
 
-## Tomcat give an error Cannot assign requested address on startup
+### Users not able to join Listen Only mode
 
-If your server has multiple IP addresses, Tomcat might not pick the right address to bind.  This could throw an error on installation when tomcat is attempting to install.
-
-Check `/var/log/tomcat7/catalina.out` for the following error
+When doing `sudo bbb-conf --check`, you may see the warning
 
 ```
-Jan 30, 2018 9:17:37 AM org.apache.catalina.core.StandardServer await
-SEVERE: StandardServer.await: create[localhost:8005]:
-java.net.BindException: Cannot assign requested address (Bind failed)
- at java.net.PlainSocketImpl.socketBind(Native Method)
+voice Application failed to register with sip server
 ```
 
-If you see this, first ensure that there isn't another copy of tomcat running by doing `ps -aef | grep tomcat7`.  If you do see another copy running, try killing it and then restarting tomcat.  
+This error occurs when `bbb-apps-sip` isn't able to make a SIP call to FreeSWITCH.  You'll see this in BigBlueButton when users click the headset icon and don't join the voice conference.
 
-If you still see the same error in `catalina.out`, then `/etc/tomcat7/server.xml` and change
-
-```xml
-<Server port="8005" shutdown="SHUTDOWN">
-```
-
-```xml
-<Server address="0.0.0.0" port="8005" shutdown="SHUTDOWN">
-```
-
-Restart tomcat7 again and it should start normally.
-
-## WebRTC video not working with Kurento
-
-Check the value for `/proc/sys/net/ipv4/tcp_syncookies` that it contains the value `1`.
+One possible cause for this is you have just installed BigBlueButton, but not restarted it.  The packages do not start up the BigBlueButton components in the right order.  To restart BigBlueButton, do the following:
 
 ```bash
-$ cat /proc/sys/net/ipv4/tcp_syncookies
-1
+$ sudo bbb-conf --restart
+$ sudo bbb-conf --check
 ```
 
-If not, edit `/etc/sysctl.conf` and set the value for `net.ipv4.tcp_syncookies` to `1`.
+If you don't want FreeSWITCH to bind to 127.0.0.1, you need to figure out which IP address its using.  First, determine the IP address FreeSWITCH is monitoring for incoming SIP calls with the following command:
 
-```ini
-net.ipv4.tcp_syncookies = 1
+```bash
+$ netstat -ant | grep 5060
 ```
 
-Save the file and restart.   
+You should see an output such as
 
-## Package install fails with sed error
+```
+tcp        0      0 234.147.116.3:5060    0.0.0.0:*               LISTEN
+```
+
+In this example, FreeSWITCH is listening on IP address 234.147.116.3.  The IP address on your server will be different.
+
+Next, edit `/usr/share/red5/webapps/sip/WEB-INF/bigbluebutton-sip.properties` and set the value for `sip.server.host` to the IP address returned from the above command.   Save the changes (you'll need to edit the file as root to save changes).
+
+Restart BigBlueButton using the commands and run the built-in diagnostics checks.
+
+```bash
+$ sudo bbb-conf --clean
+$ sudo bbb-conf --check
+```
+
+## Installation and packages
+
+### The following packages have unmet dependencies
+
+When installing the latest build of BigBlueButton, the package `bbb-conf` now uses `yq` to manage YAML files.  
+
+You need to add the repository `ppa:rmescandon/yq` to your server.  For steps on how to do this, see [Update your server](http://docs.bigbluebutton.org/2.2/install.html#1-update-your-server) in the BigBlueButton 2.2 install guide.
+
+Alternatively, if you have not made any customizations to BigBlueButton (outside of using `bbb-conf`), you can use [bbb-install.sh](https://github.com/bigbluebutton/bbb-install) to install/upgrade to the latest version (the `bbb-install.sh` script will automatically install the repository for `yq`).
+
+### No Symbolic Link
+
+If you've installed/uninstalled BigBlueButton packages, you may get a `No Symbolic Link` warning from `bbb-conf --check`:
+
+```
+** Potential Problems **
+    nginx (conf): no symbolic link in /etc/nginx/sites-enabled for bigbluebutton
+```
+
+To solve this,  add a symbolic link to nginx for the BigBlueButton site:
+
+```bash
+$ sudo ln -s /etc/nginx/sites-available/bigbluebutton /etc/nginx/sites-enabled/bigbluebutton
+$ sudo /etc/init.d/nginx restart
+```
+
+### Package install fails with sed error
 
 Some of the BigBlueButton packages use `sed` scripts to extract contents from configuration files.  If the file does not exist at the time of the script's execution, or the sed script matches multiple entries in a file (such as when a configuration line is commented out), you can see an error such as
 
@@ -701,136 +542,72 @@ $ sudo apt-get install -f
 
 You should now see each command in `bbb-conf.postinst` as it executes upto the line in which the error occurs.  Post this output to `https://groups.google.com/forum/#!forum/bigbluebutton-setup` for help in resolving the issue.
 
-## Configure BigBluebutton/FreeSWITCH to support IPV6
+### Errors with packages
 
-The HTML5 client now enables users on mobile devices to connect to a BigBlueButton server.  However, on some cellular networks iOS devices only receive an IPV6 address.
-
-To enable BigBlueButton (FreeSWITCH) to accept incoming web socket connections on IPV6, the BigBlueButton server must have an IPV6 address.  You also need to make the following changes to the server.
-
-First, create the file `/etc/nginx/conf.d/bigbluebutton_sip_addr_map.conf` with this content:
-
-```nginx
-map $remote_addr $freeswitch_addr {
-    "~:"    [2001:db8::1];
-    default    192.0.2.1;
-}
-```
-
-replacing the ip addresses `192.0.2.1` with the system's external IPV4 addresses, and replace `2001:db8::1` with the system's external IPV6 address.  Next, edit the file `/etc/bigbluebutton/nginx/sip.nginx` to have the following:
-
-```nginx
-proxy_pass https://$freeswitch_addr:7443;
-```
-
-Next, ensure all of the following params are present in freeswitch's `sip_profiles/external-ipv6.xml`:
-
-* ws-binding
-* wss-binding
-* rtcp-audio-interval-msec
-* rtcp-video-interval-msec
-* dtmf-type
-* liberal-dtmf
-* enable-3pcc
-
-If any are missing, copy them from `sip_profiles/external.xml`, then restart BigBlueButton (`sudo bbb-conf --restart`).
-
-## FreeSWITCH fails to bind to IPV4
-
-In rare occasions after shutdown/restart, the FreeSWITCH database can get corrupted.  This will cause FreeSWITCH to have problems binding to IPV4 address (you may see error 1006 when users try to connect).  
-
-To check, look in `/opt/freeswitch/var/log/freeswitch/freeswitch.log` for errors related to loading the database.
+Some hosting providers do not provide a complete `/etc/apt/source.list`.  If you are finding your are unable to install a package, try replacing your `/etc/apt/sources.list` with the following
 
 ```
-2018-10-25 11:05:11.444727 [ERR] switch_core_db.c:108 SQL ERR [unsupported file format]
-2018-10-25 11:05:11.444737 [ERR] switch_core_db.c:223 SQL ERR [unsupported file format]
-2018-10-25 11:05:11.444759 [NOTICE] sofia.c:5949 Started Profile internal-ipv6 [sofia_reg_internal-ipv6]
-2018-10-25 11:05:11.444767 [CRIT] switch_core_sqldb.c:508 Failure to connect to CORE_DB sofia_reg_external!
-2018-10-25 11:05:11.444772 [CRIT] sofia.c:3049 Cannot Open SQL Database [external]!
+deb http://archive.ubuntu.com/ubuntu xenial main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu xenial-updates main restricted universe multiverse
+deb http://security.ubuntu.com/ubuntu xenial-security main restricted universe multiverse
 ```
 
-If you see these errors, clear the FreeSWITCH database (BigBlueButton doesn't use the database and FreeSWITCH will recreate it on startup).
+then do
 
 ```bash
-$ sudo systemctl stop freeswitch
-$ rm -rf /opt/freeswitch/var/lib/freeswitch/db/*
-$ sudo systemctl start freeswitch
+$ sudo apt-get update
 ```
 
-## Unit kurento-media-server.service is masked
+and try installing BigBlueButton again from the beginning.
 
-If `sudo bbb-conf --check` returns the warning
+## WebRTC errors (1001, 1002,...)
 
-```
-Restarting BigBlueButton 2.0.0-RC9 (and cleaning out all log files) ...
-Stopping BigBlueButton
- ... cleaning log files
-Starting BigBlueButton
-Failed to start kurento-media-server.service: Unit kurento-media-server.service is masked.
-```
+WebRTC offers very high-quality audio.  However, the user's network settings (or firewall) may not allow WebRTC to connect (or keep connected).
 
-You can unmask Kurento using the command
+Here are the following lists the possible WebRTC error messages that a user may encounter:
 
-```bash
-$ systemctl unmask kurento-media-server.service
-```
+* **1001: WebSocket disconnected** - The WebSocket had connected successfully and has now disconnected.  Possible Causes:
+  * Loss of internet connection
+  * Nginx restarting can cause this
+* **1002: Could not make a WebSocket connection** - The initial WebSocket connection was unsuccessful.  Possible Causes:
+  * Firewall blocking ws protocol
+  * Server is down or improperly configured
+  * See potential solution [here](https://github.com/bigbluebutton/bigbluebutton/issues/2628).
+* **1003: Browser version not supported** - Browser doesn’t implement the necessary WebRTC API methods.  Possible Causes:
+  * Out of date browser
+* **1004: Failure on call** - The call was attempted, but failed.  Possible Causes:
+  * For a full list of causes refer here, http://sipjs.com/api/0.6.0/causes/
+  * There are 24 different causes so I don’t really want to list all of them
+  * Solution for this issue [outlined here](https://groups.google.com/forum/#!msg/bigbluebutton-setup/F2MlW6Voj-0/ZXDq5_-uEQAJ).
+* **1005: Call ended unexpectedly** - The call was successful, but ended without user requesting to end the session.  Possible Causes:
+  * Unknown
+* **1006: Call timed out** - The library took too long to try and connect the call.  Possible Causes:
+  * Previously caused by Firefox 33-beta on Mac.   We've been unable to reproduce since release of FireFox 34
+* **1007: ICE negotiation failed** - The browser and FreeSWITCH try to negotiate ports to use to stream the media and that negotiation failed.  Possible Causes:
+  * NAT is blocking the connection
+  * Firewall is blocking the UDP connection/ports
+* **1008: Call transfer failed** - A timeout while waiting for FreeSWITCH to transfer from the echo test to the real conference. This might be caused by a misconfiguration in FreeSWITCH, or there might be a media error and the DTMF command to transfer didn't go through (In this case, the voice in the echo test probably didn't work either.)
+* **1009: Could not fetch STUN/TURN server information** - This indicates either a BigBlueButton bug (or you're using an unsupported new client/old server combination), but could also happen due to a network interruption.
+* **1010: ICE negotiation timeout** - After the call is accepted the client's browser and the server try and negotiate a path for the audio data. In some network setups this negotiation takes an abnormally long time to fail and this timeout is set to avoid the client getting stuck.
+* **1020: Media cloud could not reach the server** - See how to solve this [here](https://github.com/bigbluebutton/bigbluebutton/issues/6797#issuecomment-607866043).
 
-## Delete recordings older than N days
+## Networking
 
-You may want to not keep recordings that are older than N days.  Add the following script to `/etc/cron.daily/delete-old-recordings`:
+### Server running behind NAT
 
-```bash
-#!/bin/bash
+The [following issue](https://github.com/bigbluebutton/bigbluebutton/issues/8792) might be helpful in debugging if you run into errors and your server is behind NAT.
 
-MAXAGE=7
+### Could not get your microphone for a WebRTC call
 
-LOGFILE=/var/log/bigbluebutton/bbb-recording-cleanup.log
+Chrome requires (As of Chrome 47) that to access the user's microphone for WebRTC your site must be serving pages via HTTPS (that is, nginx is configured with a SSL certificate).
 
-shopt -s nullglob
+If the user attempts to share their microphone and your BigBlueButton sever is not configured for SSL, Chrome will block access and BigBlueButton will report the following error
 
-NOW=$(date +%s)
+   _WebRTC Audio Failure: Detected the following WebRTC issue: Could not get your microphone for a WebRTC call. Do you want to try flash instead?_
 
-echo "$(date --rfc-3339=seconds) Deleting recordings older than ${MAXAGE} days" >>"${LOGFILE}"
+To enable Chrome to access the user's microphone, see [Configure HTTPS on BigBlueButton](/2.2/install.html#configure-ssl-on-your-bigbluebutton-server).
 
-for donefile in /var/bigbluebutton/recording/status/published/*-presentation.done ; do
-        MTIME=$(stat -c %Y "${donefile}")
-        # Check the age of the recording
-        if [ $(( ( $NOW - $MTIME ) / 86400 )) -gt $MAXAGE ]; then
-                MEETING_ID=$(basename "${donefile}")
-                MEETING_ID=${MEETING_ID%-presentation.done}
-                echo "${MEETING_ID}" >> "${LOGFILE}"
-
-                bbb-record --delete "${MEETING_ID}" >>"${LOGFILE}"
-        fi
-done
-
-for eventsfile in /var/bigbluebutton/recording/raw/*/events.xml ; do
-        MTIME=$(stat -c %Y "${eventsfile}")
-        # Check the age of the recording
-        if [ $(( ( $NOW - $MTIME ) / 86400 )) -gt $MAXAGE ]; then
-                MEETING_ID="${eventsfile%/events.xml}"
-                MEETING_ID="${MEETING_ID##*/}"
-                echo "${MEETING_ID}" >> "${LOGFILE}"
-
-                bbb-record --delete "${MEETING_ID}" >>"${LOGFILE}"
-        fi
-done
-```
-
-You can modify length your server will retain recordings by changing `MAXAGE=7` to a different number.  After you create the file, make sure it is executable.
-
-```powershell
-$ chmod +x /etc/cron.daily/etc/cron.daily/delete-old-recordings
-```
-
-## The following packages have unmet dependencies
-
-When installing the latest build of BigBlueButton, the package `bbb-conf` now uses `yq` to manage YAML files.  
-
-You need to add the repository `ppa:rmescandon/yq` to your server.  For steps on how to do this, see [Update your server](http://docs.bigbluebutton.org/2.2/install.html#1-update-your-server) in the BigBlueButton 2.2 install guide.
-
-Alternatively, if you have not made any customizations to BigBlueButton (outside of using `bbb-conf`), you can use [bbb-install.sh](https://github.com/bigbluebutton/bbb-install) to install/upgrade to the latest version (the `bbb-install.sh` script will automatically install the repository for `yq`).
-
-## The browser is not supported
+### The browser is not supported
 
 When you attempt to join a BigBlueButton session, the client looks for supported browsers before fully loading.  The client gets its list of supported browsers from `/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml`.  You can see the list of supported browsers at the bottom.  For example,
 
@@ -860,7 +637,76 @@ Next, to add this as a supported browser, append to `settings.yml`
 
 save the updated `settings.yml` file, and then restart your BigBlueButton server with `sudo bbb-conf --restart`.  Note any browser you add must support WebRTC libraries (not all do), so be sure to check it first with [https://test.webrtc.org/](https://test.webrtc.org/).
 
-## 404 Error when loading the client
+### Tomcat shows "Cannot assign requested address on startup"
+
+If your server has multiple IP addresses, Tomcat might not pick the right address to bind.  This could throw an error on installation when tomcat is attempting to install.
+
+Check `/var/log/tomcat7/catalina.out` for the following error
+
+```
+Jan 30, 2018 9:17:37 AM org.apache.catalina.core.StandardServer await
+SEVERE: StandardServer.await: create[localhost:8005]:
+java.net.BindException: Cannot assign requested address (Bind failed)
+ at java.net.PlainSocketImpl.socketBind(Native Method)
+```
+
+If you see this, first ensure that there isn't another copy of tomcat running by doing `ps -aef | grep tomcat7`.  If you do see another copy running, try killing it and then restarting tomcat.  
+
+If you still see the same error in `catalina.out`, then `/etc/tomcat7/server.xml` and change
+
+```xml
+<Server port="8005" shutdown="SHUTDOWN">
+```
+
+```xml
+<Server address="0.0.0.0" port="8005" shutdown="SHUTDOWN">
+```
+
+Restart tomcat7 again and it should start normally.
+
+### nginx not running
+
+The common reasons for nginx not running are inability to bind to port 80 and configuration errors.  To check if port 80 is already in use, use
+
+```bash
+$ sudo netstat -ant
+```
+
+to see if any process is currently bound to port 80.  If so, check to see if another web server is installed.  If so, then stop the web server and try to restart nginx.  One of the server requirements before you install BigBlueButton is that port 80 is not in use by another application (such as Apache).  For details on why this is a requirements, see [We recommend running BigBlueButton on port 80](http://docs.bigbluebutton.org/support/faq.html#we-recommend-running-bigbluebutton-on-port-80443).
+
+If port 80 is free, check if your nginx configuration file has errors.  Try a restart of nginx
+
+```bash
+$ sudo systemctl restart nginx
+```
+
+and look for the output of
+
+```
+   [ OK ]
+```
+
+If you see `[ Fail ]`, then your nginx configuration files might have a syntax error.  Check the syntax of the nginx configuration files using the command
+
+```bash
+$ sudo nginx -t
+```
+
+and see if it reports any errors.  You can also check the error.log file for nginx to see what errors it gives on startup
+
+```bash
+$ sudo cat /var/log/nginx/error.log
+```
+
+### "Welcome to nginx"
+
+During installation of BigBlueButton the packaging scripts attempt to assign the correct IP address during setup. However, if the IP address changes (such as when rebooting a VM), or the first IP address was not the correct IP address for the server, you may see a "Welcome to nginx" page.  
+
+To reconfigure the BigBlueButton to use the correct IP address or hostname, see [BigBlueButton does not load](#bigbluebutton-does-not-load).
+
+## bbb-web
+
+### 404 Error when loading the client
 
 BigBlueButton 2.2 requires Java 8 as the default Java.  Recently, some Ubuntu 16.04 distributions have switched the default version of Java to Java 9 (or later).
 
@@ -882,11 +728,20 @@ update-alternatives --config java  # Choose java-8 as default
 
 Run `java -version` and confirm it now shows the default as `1.8.0`, and then restart BigBlueButton with `sudo bbb-conf --restart`
 
-## Too many open files 
+### Unable to create presentation
+
+If you see the following error in `/var/log/bigbluebutton/bbb-web.log`
+
+```
+  failed to map segment from shared object: Operation not permitted
+```
+
+use the command `mount` to check that the `/tmp` director does not have `noexec` permissions (which would prevent executables from running in the /tmp directory). If you see `noexec` for `/tmp`, you need to remount the directory with permissions that enable processes (such as the slide conversion) to execute in the `/tmp` directory.
+
+### Too many open files 
 On servers with greater than 8 CPU cores, `bbb-web` log (`/var/log/bigbluebutton/bbb-web.log`) may throw an error of `Too many open files`
 
-
-~~~
+~~~log
 Caused by: java.io.IOException: Too many open files
 ~~~
 
@@ -902,6 +757,155 @@ HERE
 $  sudo systemctl daemon-reload
 ~~~
 
-## Server running behind NAT
+### bbb-web takes a long time to startup
 
-The [following issue](https://github.com/bigbluebutton/bigbluebutton/issues/8792) might be helpful in debugging if you run into errors and your server is behind NAT.
+ `bbb-web` relies on the SecureRandom class (which uses available entropy) to provide random values for its session IDs.  On a virtualized server, however, the available entropy can run low and cause bbb-web to block for a long period before it finishes it's startup sequence (see [Slow startup of tomcat](https://stackoverflow.com/questions/28201794/slow-startup-on-tomcat-7-0-57-because-of-securerandom)).
+
+To provide `bbb-web` with more entropy, you can install haveged
+
+```bash
+$ sudo apt-get install haveged
+```
+
+For more information see [How to Setup Additional Entropy for Cloud Servers Using Haveged](https://www.digitalocean.com/community/tutorials/how-to-setup-additional-entropy-for-cloud-servers-using-haveged).
+
+### Error installing bbb-web
+
+If you get the following error during upgrade to BigBlueButton
+
+```
+Unpacking bbb-web (1:2.2.0-67) over (1:2.2.0-66) ...
+dpkg: error processing archive /var/cache/apt/archives/bbb-web_1%3a2.2.0-67_amd64.deb (--unpack):
+ trying to overwrite '/etc/bigbluebutton/nginx/web', which is also in package bbb-client 1:2.2.0-28
+dpkg-deb: error: subprocess paste was killed by signal (Broken pipe)
+Errors were encountered while processing:
+ /var/cache/apt/archives/bbb-web_1%3a2.2.0-67_amd64.deb
+E: Sub-process /usr/bin/dpkg returned an error code (1)```
+```
+
+Then first uninstall `bbb-client`
+
+```bash
+$ sudo apt-get purge bbb-client
+```
+
+and try installing BigBlueButton again.
+
+## Other errors
+
+### Root partition too small
+
+If the root partition on your BigBlueButton server is too small (for disk space requirements see [Before you install](/2.2/install.html#before-you-install)), we recommend moving the following directories to an external partition with sufficient disk space.
+
+BigBlueButton processing and storage of recordings:
+
+Location of all media directories on disk [available here](/dev/recording.html#media-storage).
+
+To make the move, we'll first stop BigBlueButton, then move the above directories to a new location on the external partition, create symbolic links from the original locations to the new locations, and restart BigBlueButton.  
+
+In the following example, the external partition is mounted on `/mnt`.
+
+```bash
+$ sudo bbb-conf --stop
+
+$ sudo mv /var/freeswitch/meetings /mnt
+$ sudo ln -s /mnt/recordings /var/freeswitch/meetings
+
+$ sudo mv /usr/share/red5/webapps/video/streams /mnt
+$ sudo ln -s /mnt/streams /usr/share/red5/webapps/video/streams
+
+$ sudo /var/bigbluebutton /mnt
+$ sudo ln -s /mnt/bigbluebutton /var/bigbluebutton
+
+$ sudo bbb-conf --start
+```
+
+### BigBlueButton does not load
+
+If your has changed it's network connection (such as on reboot), you can clean most of BigBlueButton's configuration files with the following steps.
+
+```bash
+$ sudo bbb-conf --setip <ip_address_or_hostname>
+
+$ sudo bbb-conf --clean
+$ sudo bbb-conf --check
+```
+
+For more information see [bbb-conf options](/install/bbb-conf.html).
+
+### Running within an LXD Container
+
+[LXD](https://www.ubuntu.com/containers/lxd) is a very powerful container system for Ubuntu lets you run full Ubuntu 16.04 servers within a container.  Because you can easily clone and snapshot LXD containers, they are ideal for development and testing of BigBlueButton.
+
+However, if you install BigBlueButton within an LXD container, you will get the following error from `sudo bbb-conf --check`
+
+```
+** Potential problems described below **
+
+#
+# Error: Unable to connect to the FreeSWITCH Event Socket Layer on port 8021
+```
+
+You'll also get an error from starting FreeSWITCH with `bbb-conf --restart`.  When you try `systemctl status freeswitch.service`, you'll see an error with SETSCHEDULER.
+
+```bash
+$ sudo systemctl status freeswitch.service
+● freeswitch.service - freeswitch
+   Loaded: loaded (/lib/systemd/system/freeswitch.service; enabled; vendor preset: enabled)
+   Active: inactive (dead) (Result: exit-code) since Wed 2017-04-26 16:34:24 UTC; 23h ago
+  Process: 7038 ExecStart=/opt/freeswitch/bin/freeswitch -u freeswitch -g daemon -ncwait $DAEMON_OPTS (code=exited, status=214/SETSCHEDULER)
+
+Apr 26 16:34:24 big systemd[1]: Failed to start freeswitch.
+Apr 26 16:34:24 big systemd[1]: freeswitch.service: Unit entered failed state.
+Apr 26 16:34:24 big systemd[1]: freeswitch.service: Failed with result 'exit-code'.
+Apr 26 16:34:24 big systemd[1]: freeswitch.service: Service hold-off time over, scheduling restart.
+Apr 26 16:34:24 big systemd[1]: Stopped freeswitch.
+Apr 26 16:34:24 big systemd[1]: freeswitch.service: Start request repeated too quickly.
+Apr 26 16:34:24 big systemd[1]: Failed to start freeswitch.
+```
+
+This error occurs because the default systemd unit script for FreeSWITCH tries to run with permissions not available to the LXD container.  To run FreeSWITCH within an LXD container, edit `/lib/systemd/system/freeswitch.service` and replace with the following
+
+```properties
+[Unit]
+Description=freeswitch
+After=syslog.target network.target local-fs.target
+
+[Service]
+Type=forking
+PIDFile=/opt/freeswitch/var/run/freeswitch/freeswitch.pid
+Environment="DAEMON_OPTS=-nonat"
+EnvironmentFile=-/etc/default/freeswitch
+ExecStart=/opt/freeswitch/bin/freeswitch -u freeswitch -g daemon -ncwait $DAEMON_OPTS
+TimeoutSec=45s
+Restart=always
+WorkingDirectory=/opt/freeswitch
+User=freeswitch
+Group=daemon
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Then enter the following commands to load the new unit file and restart BigBlueButton.
+
+```bash
+$ sudo systemctl daemon-reload
+$ sudo bbb-conf --restart
+```
+
+You can run BigBlueButton within a LXD container.
+
+## Legacy errors
+
+### Conference not found errors
+
+The command `sudo bbb-conf --debug` searches through the red5, tomcat7, and nginx logs looking for errors and exceptions.  However, the messages such as
+
+```
+    -- ERRORS found in /usr/share/red5/log/* --
+/usr/share/red5/log/bigbluebutton.log:2015-05-02 13:50:37,681-04:00 [pool-17-thread-1] ERROR o.b.w.v.f.a.PopulateRoomCommand - Not XML: [Conference 78505 not found]
+```
+
+are innocuous and can be ignored.
+

--- a/_posts/2019-02-14-troubleshooting.md
+++ b/_posts/2019-02-14-troubleshooting.md
@@ -125,54 +125,6 @@ If you see text after the line `** Potential problems described below **`, then 
 
 ## Recording
 
-### Delete recordings older than N days
-
-You may want to not keep recordings that are older than N days.  Add the following script to `/etc/cron.daily/delete-old-recordings`:
-
-```bash
-#!/bin/bash
-
-MAXAGE=7
-
-LOGFILE=/var/log/bigbluebutton/bbb-recording-cleanup.log
-
-shopt -s nullglob
-
-NOW=$(date +%s)
-
-echo "$(date --rfc-3339=seconds) Deleting recordings older than ${MAXAGE} days" >>"${LOGFILE}"
-
-for donefile in /var/bigbluebutton/recording/status/published/*-presentation.done ; do
-        MTIME=$(stat -c %Y "${donefile}")
-        # Check the age of the recording
-        if [ $(( ( $NOW - $MTIME ) / 86400 )) -gt $MAXAGE ]; then
-                MEETING_ID=$(basename "${donefile}")
-                MEETING_ID=${MEETING_ID%-presentation.done}
-                echo "${MEETING_ID}" >> "${LOGFILE}"
-
-                bbb-record --delete "${MEETING_ID}" >>"${LOGFILE}"
-        fi
-done
-
-for eventsfile in /var/bigbluebutton/recording/raw/*/events.xml ; do
-        MTIME=$(stat -c %Y "${eventsfile}")
-        # Check the age of the recording
-        if [ $(( ( $NOW - $MTIME ) / 86400 )) -gt $MAXAGE ]; then
-                MEETING_ID="${eventsfile%/events.xml}"
-                MEETING_ID="${MEETING_ID##*/}"
-                echo "${MEETING_ID}" >> "${LOGFILE}"
-
-                bbb-record --delete "${MEETING_ID}" >>"${LOGFILE}"
-        fi
-done
-```
-
-You can modify length your server will retain recordings by changing `MAXAGE=7` to a different number.  After you create the file, make sure it is executable.
-
-```powershell
-$ chmod +x /etc/cron.daily/etc/cron.daily/delete-old-recordings
-```
-
 ### Recording not processing after upgrading
 
 If after updating from BigBlueButton 2.0 to BigBlueButton 2.2 your recordings are not processing, and if you are seeing `Permission denied` errors in `/var/log/bigbluebutton/bbb-rap-worker.log`


### PR DESCRIPTION
Similar to #157. Categorizes issues under headings to make troubleshooting easier. Also a few minor cosmetic changes like deleting trailing white spaces, replacing ~~~ legacy language blocks, and setting languages for the ``` blocks. Only major deletion involved was merging a duplicate suggestion: "Delete recordings older than N days".