### PR TITLE
Add WSL + running HTML5 in production

### DIFF
--- a/_posts/2019-02-14-dev.md
+++ b/_posts/2019-02-14-dev.md
@@ -54,9 +54,14 @@ For example, suppose you modify the BigBlueButton client and something isn't wor
 
 ### Developing on Windows
 
-To develop BigBlueButton from within Windows, use VMWare Player or VirtualBox to create first an Ubuntu 16.04 64-bit virtual machine (VM).  The associated documentation for VMWare Player and VirtualBox will guide you on setting up a new 16.04 64-bit VM.
+To develop BigBlueButton from within Windows, you have two options:
 
-When setting up the VM, it does not matter to BigBlueButton if you setup Ubuntu 16.04 server or desktop.  If you install desktop, you'll have the option of using a graphical interface to edit files.  When running the VM, you will need a host operating system capable of running a [64-bit virtual machine](http://stackoverflow.com/questions/56124/can-i-run-a-64-bit-vmware-image-on-a-32-bit-machine).
+* use Windows Subsystem for Linux
+* use VMWare Player or VirtualBox to create a virtual machine (VM).
+
+Choose the OS to be Ubuntu 16.04 64-bit. The associated documentation for VMWare Player and VirtualBox or WSL will guide you on setting up a new 16.04 64-bit VM.
+
+**Note:** When setting up the VM, it does not matter to BigBlueButton if you setup Ubuntu 16.04 server or desktop.  If you install desktop, you'll have the option of using a graphical interface to edit files.  When running the VM, you will need a host operating system capable of running a [64-bit virtual machine](http://stackoverflow.com/questions/56124/can-i-run-a-64-bit-vmware-image-on-a-32-bit-machine).
 
 ### Root Privileges
 
@@ -291,6 +296,26 @@ By default, the client will run in `development` mode. Loading into production e
 ```bash
 $ NODE_ENV=production npm start
 ```
+
+## Production
+
+Using NODE_ENV=production is not meant to be actually used in production, see [here](https://guide.meteor.com/deployment.html#never-use-production-flag) for more information. Instead, you should build the meteor app so that the `bbb-html5` service can work with it.
+
+First, ensure that you're in the `bigbluebutton-html5` directory. If you follow the instructions above and have `ubuntu` as your user, you can run the following:
+
+```bash
+meteor build ---server-only /home/ubuntu/dev/bigbluebutton/bigbluebutton-html5/meteorbundle
+```
+
+Meteor will build your customized version into a `.tar.gz` so we need to unpack it and place it in the right directory for `bbb-html5` to use it. Run:
+
+```bash
+sudo tar -xzvf /home/ubuntu/dev/meteorbundle/*.tar.gz -C /usr/share/meteor
+```
+
+Finally, start the HTML5 client with `sudo systemctl start bbb-html5`.
+
+There we go! Remember that this will be overwritten every time you upgrade, so you may want to have some mechanism put in place to replace it, or if your changes add new functionality/solve a bug, consider upstreaming them. To avoid having to uninstall and reinstall the `bbb-html5` package to restore a working version, you may want to make a copy of the original `bundle` folder.
 
 ## HTML5 Coding Practices
 


### PR DESCRIPTION
Adds section on Windows Subsystem for Linux and addresses a common issue of how to run a customized version of HTML5 in prod. Inspired by [this thread](https://groups.google.com/forum/#!topic/bigbluebutton-dev/IZiDLqnYjEg).