### PR TITLE
fix wrong port of unencrypted TURN server config sample on bbb server

### DIFF
--- a/_posts/2019-02-14-setup-turn-server.md
+++ b/_posts/2019-02-14-setup-turn-server.md
@@ -212,7 +212,7 @@ You must configure bbb-web so that it will provide the list of turn servers to t
     
     <bean id="turn1" class="org.bigbluebutton.web.services.turn.TurnServer">
         <constructor-arg index="0" value="<random value>"/>
-        <constructor-arg index="1" value="turn:turn.example.com:443?transport=tcp"/>
+        <constructor-arg index="1" value="turn:turn.example.com:3478?transport=tcp"/>
         <constructor-arg index="2" value="86400"/>
     </bean>
 


### PR DESCRIPTION
The sample config says to configure coturn with `listening-port=3478` but the bbb config sample says that unencrypted turn should use port 443. Correct would be 3478 for unencrypted TURN in the bbb config sample too.