### PR TITLE
priority change for bbb-html5 was introduced with 2.2.31, not 2.2.30

### DIFF
--- a/_posts/2019-02-14-troubleshooting.md
+++ b/_posts/2019-02-14-troubleshooting.md
@@ -404,7 +404,7 @@ Note: If your server has an internal/exteral IP address, such as on AWS EC2 serv
 
 ### bbb-html5 fails to start with a SETSCHEDULER error
 
-As of 2.2.30, the systemd unit file for `bbb-html5.service` now contains the following lines
+As of 2.2.31, the systemd unit file for `bbb-html5.service` now contains the following lines
 
 ```ini
 CPUSchedulingPolicy=fifo


### PR DESCRIPTION
Priority change for bbb-html5 was introduced with 2.2.31, not 2.2.30.

https://github.com/bigbluebutton/bigbluebutton/releases/tag/v2.2.31