### PR TITLE
Switch coturn recommendation to Ubuntu 20.04 because of critical bugs

### DIFF
--- a/_posts/2019-02-14-setup-turn-server.md
+++ b/_posts/2019-02-14-setup-turn-server.md
@@ -28,9 +28,9 @@ Having the server behind NAT (for example, on Amazon EC2) is OK, but all incomin
 
 ## Required Software
 
-We recommend using a minimal server installation of Ubuntu 18.04.  The [coturn](https://github.com/coturn/coturn) software requires port 443 for its exclusive use in our recommended configuration, which means the server cannot have any dashboard software or other web applications running.
+We recommend using a minimal server installation of Ubuntu 20.04.  The [coturn](https://github.com/coturn/coturn) software requires port 443 for its exclusive use in our recommended configuration, which means the server cannot have any dashboard software or other web applications running.
 
-coturn is already available in the Ubuntu packaging repositories for version 18.04 and later, and it can be installed with apt-get:
+Stable versions of coturn are already available in the Ubuntu packaging repositories for version 20.04 and later, and it can be installed with apt-get:
 
 ```bash
 $ sudo apt-get update


### PR DESCRIPTION
Coturn of Ubuntu 18.04 should not be used any more and it has lots of known bugs which are annoying to work around.
This PR changes the suggested Ubuntu version for the Coturn setup to Ubuntu 20.04.

This is tested and verified as `best practice` by bunch of BBB admin groups from the German BBB User Group.