### PR TITLE
meteor 1.10.2 for 2.3dev

### DIFF
--- a/_posts/2019-02-14-dev.md
+++ b/_posts/2019-02-14-dev.md
@@ -255,7 +255,7 @@ Install Meteor.js.
 $ curl https://install.meteor.com/ | sh
 ```
 
-The HTML5 client in BigBlueButton 2.2 depends on Meteor version 1.8.x. Navigate to `bigbluebutton-html5/` and set the appropriate version of Meteor
+The HTML5 client in BigBlueButton 2.2 depends on Meteor version 1.8.x. Navigate to `bigbluebutton-html5/` and set the appropriate version of Meteor. Note that 2.3-dev needs version 1.10.2.
 
 ```
 meteor update --allow-superuser --release 1.8


### PR DESCRIPTION
As far as I remember, there had been a description about the required version of meteor for 2.3-dev. But I don't find it anymore. 

At least meteor 1.8 is not compatible with 2.3-dev, so we'd better write it here.