### PR TITLE
corrected path for pg_dumpall

### DIFF
--- a/_posts/2019-04-15-gl-config.md
+++ b/_posts/2019-04-15-gl-config.md
@@ -557,7 +557,7 @@ Before you begin, please note that this process may take some time for large dat
 ### Create a dump of your database
 ```
 cd ~/greenlight
-docker exec greenlight_db_1 /usr/bin/pg_dumpall -U postgres -f /var/lib/postgresql/data/dump.sql
+docker exec greenlight_db_1 /usr/local/bin/pg_dumpall -U postgres -f /var/lib/postgresql/data/dump.sql
 docker-compose down
 ```
 


### PR DESCRIPTION
Never seen that problem, because we have a central database. Now on the road, reading docs, copy&paste not working... missing local in path.