### PR TITLE
docs: remove outdated 2.3-dev KMS install step

### DIFF
--- a/_posts/2020-07-10-dev23.md
+++ b/_posts/2020-07-10-dev23.md
@@ -590,26 +590,6 @@ sudo apt-get install nodejs
 ```
 
 
-### Install Kurento Media Server
-##### (Note: BBB 2.3-dev uses Kurento Media Server official's repository, instead of forked version. The current version used by BBB 2.3-dev is 6.15.0)
-Add key for Kurento
-
-```bash
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5AFA7A83
-```
-Add APT's source
-```bash
-sudo tee "/etc/apt/sources.list.d/kurento.list" >/dev/null <<EOF
-# Kurento Media Server - Release packages
-deb [arch=amd64] http://ubuntu.openvidu.io/6.15.0 bionic kms6
-EOF
-```
-Install it
-```bash
-sudo apt-get update && sudo apt-get install kurento-media-server
-```
-
-
 ### Install BigBlueButton
 Add key for BigBlueButton
 ```bash


### PR DESCRIPTION
Kurento is now built alongside BigBlueButton and served by the main repo.

Manually installing upstream's version shouldn't be necessary anymore.