### PR TITLE
API docs updates - 2.3 endWhenNoModerator* create params, etc

### DIFF
--- a/_posts/2015-04-05-api.md
+++ b/_posts/2015-04-05-api.md
@@ -55,12 +55,21 @@ Updated in 2.0:
 
 Updated in 2.2:
 
+* **create** - Added `endWhenNoModerator`
 * **getRecordingTextTracks** - Get a list of the caption/subtitle files currently available for a recording.
 * **putRecordingTextTrack** - Upload a caption or subtitle file to add it to the recording. If there is any existing track with the same values for kind and lang, it will be replaced.
 
 Updated in 2.3:
- * **joinViaHtml5** was removed - everyone joins via HTML5 by default - Flash client was retired.
- * **meetingKeepEvents** was added to override `defaultKeepEvents` on meeting create
+
+* **create** - Renamed `keepEvents` to `meetingKeepEvents`, removed `joinViaHtml5`, added `endWhenNoModeratorDelayInMinutes`
+* **getDefaultConfigXML** obsolete, not used in HTML5 client
+* **setConfigXML** obsolete, not used in HTML5 client
+
+Updated in 2.4 (under development):
+
+* **getDefaultConfigXML** Removed, not used in HTML5 client
+* **setConfigXML** Removed, not used in HTML5 client
+
 
 # API Data Types
 
@@ -243,6 +252,16 @@ lockSettingsLockOnJoinConfigurable=false
 # This URL is where the BBB client is accessible. When a user sucessfully
 # enters a name and password, she is redirected here to load the client.
 bigbluebutton.web.serverURL=https://bbb.example.com
+
+
+# Param to end the meeting when there are no moderators after a certain period of time.
+# Needed for classes where teacher gets disconnected and can't get back in. Prevents
+# students from running amok.
+endWhenNoModerator=false
+
+# Number of minutes to wait for moderator rejoin before end meeting (if `endWhenNoModerator` enabled)
+endWhenNoModeratorDelayInMinutes=1
+
 ```
 
 ## Usage
@@ -393,7 +412,10 @@ http&#58;//yourserver.com/bigbluebutton/api/create?[parameters]&checksum=[checks
 | lockSettingsLockOnJoin             | Optional                | Boolean                                                                                                                                                                     | Default `lockSettingsLockOnJoin=true`. Setting to `lockSettingsLockOnJoin=false` will not apply lock setting to users when they join. (added 2.2)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | lockSettingsLockOnJoinConfigurable | Optional                | Boolean                                                                                                                                                                     | Default `lockSettingsLockOnJoinConfigurable=false`. Setting to `lockSettingsLockOnJoinConfigurable=true` will allow applying of `lockSettingsLockOnJoin` param. (added 2.2)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | guestPolicy                        | Optional                | String                                                                                                                                                                      | Default `guestPolicy=ALWAYS_ACCEPT`. Will set the guest policy for the meeting. The guest policy determines whether or not users who send a join request with `guest=true` will be allowed to join the meeting. Possible values are ALWAYS_ACCEPT, ALWAYS_DENY, and ASK_MODERATOR. |
+| ~~keepEvents~~                        | Optional                | Boolean                                                                                                                                                                      | (removed in 2.3 in favor of `meetingKeepEvents` and bigbluebutton.properties `defaultKeepEvents`) |
 | meetingKeepEvents                        | Optional                | Boolean                                                                                                                                                                      | Defaults to the value of `defaultKeepEvents`. If `meetingKeepEvents` is true BigBlueButton saves meeting events even if the meeting is not recorded (added in 2.3) |
+| endWhenNoModerator                        | Optional                | Boolean                                                                                                                                                                      | Default `endWhenNoModerator=false`. If `endWhenNoModerator` is true the meeting will end automatically after a delay - see `endWhenNoModeratorDelayInMinutes` (added in 2.3) |
+| endWhenNoModeratorDelayInMinutes                        | Optional                | Number                                                                                                                                                                      | Defaults to the value of `endWhenNoModeratorDelayInMinutes=1`. If `endWhenNoModerator` is true, the meeting will be automatically ended after this many minutes (added in 2.2) |
 
 **Example Requests:**
 
@@ -533,7 +555,7 @@ http&#58;//yourserver.com/bigbluebutton/api/join?[parameters]&checksum=[checksum
 | avatarURL      | Optional                | String   | The link for the user's avatar to be displayed when displayAvatar in config.xml is set to true. (added in 2.3).                                                                                                                                                                                                                                                                                                      |
 | redirect       | Optional (Experimental) | String   | The default behaviour of the JOIN API is to redirect the browser to the Flash client when the JOIN call succeeds. There have been requests if it's possible to embed the Flash client in a "container" page and that the client starts as a hidden DIV tag which becomes visible on the successful JOIN. Setting this variable to FALSE will not redirect the browser but returns an XML instead whether the JOIN call has succeeded or not. The third party app is responsible for displaying the client to the user. |
 | clientURL      | Optional (Experimental) | String   | Some third party apps what to display their own custom client. These apps can pass the URL containing the custom client and when redirect is not set to false, the browser will get redirected to the value of clientURL.                                                                                                                                                                                                                                                                                              |
-| joinViaHtml5   | Optional                | String   | Set to "true" to force the HTML5 client to load for the user.                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ~~joinViaHtml5~~   | Optional                | String   | Set to "true" to force the HTML5 client to load for the user.  (removed in 2.3 since HTML5 is the only client)                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | guest          | Optional                | String   | Set to "true" to indicate that the user is a guest, otherwise do NOT send this parameter.                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 
 **Example Requests:**


### PR DESCRIPTION
Also updated the list of what APIs changed in 2.3 (to the best of my knowledge) and started a section for 2.4 - API changes merged into brach `develop`