### PR TITLE
Meteor version for 2.3 unnecessary

### DIFF
--- a/_posts/2.2/2019-02-14-dev.md
+++ b/_posts/2.2/2019-02-14-dev.md
@@ -255,7 +255,7 @@ Install Meteor.js.
 $ curl https://install.meteor.com/ | sh
 ```
 
-The HTML5 client in BigBlueButton 2.2 depends on Meteor version 1.8.x. Navigate to `bigbluebutton-html5/` and set the appropriate version of Meteor. Note that 2.3-dev needs version 1.10.2.
+The HTML5 client in BigBlueButton 2.2 depends on Meteor version 1.8.x. Navigate to `bigbluebutton-html5/` and set the appropriate version of Meteor.
 
 ```
 meteor update --allow-superuser --release 1.8


### PR DESCRIPTION
This may not be necessary anymore because the HTML5 development section for 2.3 is separately written now.