### PR TITLE
test, test23 servers renamed

### DIFF
--- a/_posts/2.2/2019-02-15-install.md
+++ b/_posts/2.2/2019-02-15-install.md
@@ -30,8 +30,6 @@ The BigBlueButton client offers:
 - Fully accessible to screen readers
 - Share videos from various providers (YouTube, Twitch, etc.) during the session
 
-You can try the latest version of the HTML5 client at [https://test.bigbluebutton.org/](https://test.bigbluebutton.org/).
-
 ## Installation choices
 
 When installing BigBlueButton you have three choices: `bbb-install.sh`, Ansible (for large scale deployments) and step-by-step.
@@ -602,7 +600,7 @@ If this server is intended for production, you should also
 We provide two publically accessible servers that you can use for testing:
 
 - [https://demo.bigbluebutton.org](https://demo.bigbluebutton.org/) - Runs the latest stable of build of BigBlueButton with the Greenlight front-end
-- [https://test.bigbluebutton.org](https://test.bigbluebutton.org) - Runs the latest developer build of BigBlueButton
+- [https://test22.bigbluebutton.org](https://test22.bigbluebutton.org) - Runs the latest developer build of BigBlueButton
 
 To learn more about integrating BigBlueButton with your application, check out the [BigBlueButton API documentation](http://docs.bigbluebutton.org/dev/api.html). To see videos of BigBlueButton HTML5 client, see [https://bigbluebutton.org/html5](https://bigbluebutton.org/html5).
 

--- a/_posts/2.3/2021-05-01-install.md
+++ b/_posts/2.3/2021-05-01-install.md
@@ -335,7 +335,7 @@ If this server is intended for production, you should also
 We provide two publically accessible servers that you can use for testing:
 
 - [https://demo.bigbluebutton.org](https://demo.bigbluebutton.org/) - Runs the latest stable of build of BigBlueButton with the Greenlight front-end
-- [https://test23.bigbluebutton.org](https://test23.bigbluebutton.org) - Runs the latest build (usually ahead of the general release by a few days) BigBlueButton 2.3
+- [https://test.bigbluebutton.org](https://test.bigbluebutton.org) - Runs the latest build (usually ahead of the general release by a few days) BigBlueButton 2.3
 
 To learn more about integrating BigBlueButton with your application, check out the [BigBlueButton API documentation](http://docs.bigbluebutton.org/dev/api.html). To see videos of BigBlueButton HTML5 client, see [https://bigbluebutton.org/html5](https://bigbluebutton.org/html5).
 


### PR DESCRIPTION
The 2.2 test server test.bigbluebutton.org was renamed to test22.bigbluebutton.org 
The 2.3 test server test23.bigbluebutton.org was renamed to test.bigbluebutton.org 