### PR TITLE
Add instructions for enabling recording formats to 2.3 install docs

### DIFF
--- a/_posts/2.3/2021-05-01-install.md
+++ b/_posts/2.3/2021-05-01-install.md
@@ -445,6 +445,47 @@ One challenge in maintaining a BigBlueButton 2.2 server was the packaging script
 
 The full description for local overrides for configuration files was moved to [Administration -> Configuration Files](/admin/configuration-files#local-overrides-for-configuration-settings)
 
+## Installing additional recording processing formats
+
+In addition to the `presentation` format that is installed and enabled by default, there are several optional recording formats available for BigBlueButton:
+
+* `notes`: Makes the shared notes from the meeting available as a document.
+* `screenshare`: Generate a single video file from the screensharing and meeting audio.
+* `podcast`: Generate an audio-only recording.
+
+The processing scripts and playback support files for these recording formats can be installed from the packages named `bbb-playback-formatname` (e.g. `bbb-playback-notes`)
+
+There is currently an issue where the recording formats are not automatically enabled when they are installed - see [#12241](https://github.com/bigbluebutton/bigbluebutton/issues/12241) for details.
+
+In order to enable the recording formats manually, you need to edit the file `/usr/local/bigbluebutton/core/scripts/bigbluebutton.yml`. Look for the section named `steps:`. In this section, the recording processing workflow is defined, including what recording processing steps are performed, and what order they need to be performed in.
+
+To enable a new recording format, you need to add a new step named `process:formatname` that runs after the step named captions, and a new step named `publish:formatname` that runs after `process:formatname`. You may have to convert some of the steps to list format.
+
+For example, here are the stock steps in BigBlueButton 2.3 with the `presentation` format enabled:
+
+```yml
+steps:
+  archive: "sanity"
+  sanity: "captions"
+  captions: "process:presentation"
+  "process:presentation": "publish:presentation"
+```
+
+If you additionally enable the `notes` recording format, the steps will have to be changed to look like this:
+
+```yml
+steps:
+  archive: "sanity"
+  sanity: "captions"
+  captions:
+    - "process:presentation"
+    - "process:notes"
+  "process:presentation": "publish:presentation"
+  "process:notes": "publish:notes"
+```
+
+This pattern can be repeated for additional recording formats. Note that it's very important to put the step names containing a colon (`:`) in quotes.
+
 # Troubleshooting 
 
 ## Package locales-all is not available


### PR DESCRIPTION
Since bigbluebutton/bigbluebutton#12241 remains an issue, for the time being document the steps to enable additional recording formats after installing them.