### PR TITLE
Update with Learning Dashboard configs

### DIFF
--- a/_data/create.yml
+++ b/_data/create.yml
@@ -225,8 +225,12 @@
   default: "SMART_LAYOUT"
   description: "Will set the default layout for the meeting. Possible values are: LEGACY, CUSTOM_LAYOUT, SMART_LAYOUT, PRESENTATION_FOCUS, VIDEO_FOCUS. (added 2.4)"
 
-- name: "activityReportTracking"
+- name: "learningDashboardEnabled"
   type: "Boolean"
   default: "true"
-  description: "Default <code class=\"language-plaintext highlighter-rouge\">activityReportTracking=true</code>. When this option is enabled BigBlueButton generates a Dashboard where moderators can view a summary of the activities of the meeting"
+  description: "Default <code class=\"language-plaintext highlighter-rouge\">learningDashboardEnabled=true</code>. When this option is enabled BigBlueButton generates a Dashboard where moderators can view a summary of the activities of the meeting"
 
+- name: "learningDashboardCleanupEnabled"
+  type: "Boolean"
+  default: "true"
+  description: "Default <code class=\"language-plaintext highlighter-rouge\">learningDashboardCleanupEnabled=true</code>. When this option is enabled the Learning Dashboard will become unavailable 2 minutes after meeting ends"

--- a/_data/create.yml
+++ b/_data/create.yml
@@ -230,7 +230,7 @@
   default: "true"
   description: "Default <code class=\"language-plaintext highlighter-rouge\">learningDashboardEnabled=true</code>. When this option is enabled BigBlueButton generates a Dashboard where moderators can view a summary of the activities of the meeting"
 
-- name: "learningDashboardCleanupEnabled"
-  type: "Boolean"
-  default: "true"
-  description: "Default <code class=\"language-plaintext highlighter-rouge\">learningDashboardCleanupEnabled=true</code>. When this option is enabled the Learning Dashboard will become unavailable 2 minutes after meeting ends"
+- name: "learningDashboardCleanupDelayInMinutes"
+  type: "Number"
+  default: "2"
+  description: "Default <code class=\"language-plaintext highlighter-rouge\">learningDashboardCleanupDelayInMinutes=2</code>. This option set the delay (in minutes) before the Learning Dashboard become unavailable after the end of the meeting. If this value is zero, the Learning Dashboard will keep available permanently"

--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -69,7 +69,7 @@ Updated in 2.4 (under development):
 
 - **getDefaultConfigXML** Removed, not used in HTML5 client
 - **setConfigXML** Removed, not used in HTML5 client
-- **create** - Added `meetingLayout`, `activityReportTracking`
+- **create** - Added `meetingLayout`, `learningDashboardEnabled`, `learningDashboardCleanupEnabled`
 
 # API Data Types
 

--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -69,7 +69,7 @@ Updated in 2.4 (under development):
 
 - **getDefaultConfigXML** Removed, not used in HTML5 client
 - **setConfigXML** Removed, not used in HTML5 client
-- **create** - Added `meetingLayout`, `learningDashboardEnabled`, `learningDashboardCleanupEnabled`
+- **create** - Added `meetingLayout`, `learningDashboardEnabled`, `learningDashboardCleanupDelayInMinutes`
 
 # API Data Types
 


### PR DESCRIPTION
This PR update Doc with configs related with Learning Dashboard.

- Replaces `activityReportTracking` with `learningDashboardEnabled`.
- Includes `learningDashboardCleanupEnabled`