### PR TITLE
Update bbb_hide_presentation parameter description

### DIFF
--- a/_posts/admin/2019-02-14-customize.md
+++ b/_posts/admin/2019-02-14-customize.md
@@ -1287,7 +1287,7 @@ Useful tools for development:
 | Parameter                                  | Description                                                                                                      | Default value |
 | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ------------- |
 | `userdata-bbb_auto_swap_layout=`           | If set to `true`, the presentation area will be minimized when a user joins a meeting.                           | `false`       |
-| `userdata-bbb_hide_presentation=`          | If set to `true`, the presentation area will be minimized until opened                                           | `false`       |
+| `userdata-bbb_hide_presentation=`          | If set to `true`, the presentation area will not be displayed.                                           | `false`       |
 | `userdata-bbb_show_participants_on_login=` | If set to `false`, the participants panel (and the chat panel) will not be displayed until opened.               | `true`        |
 | `userdata-bbb_show_public_chat_on_login=`  | If set to `false`, the chat panel will not be visible on page load until opened. Not the same as disabling chat. | `true`        |
 


### PR DESCRIPTION
Removes "until opened" part of the `bbb_hide_presentation` description, making it easier to understand the difference between it and `bbb_auto_swap_layout`.