### PR TITLE
Keep PostgresSQL up to date (version 13.X)

### DIFF
--- a/_posts/greenlight/2019-04-15-gl-config.md
+++ b/_posts/greenlight/2019-04-15-gl-config.md
@@ -580,7 +580,7 @@ image: postgres:9.5
 ```
 With:
 ```
-image: postgres:13.2-alpine
+image: postgres:13-alpine
 ```
 
 ### Import database dump into new database


### PR DESCRIPTION
To keep the docker container of the database server up to date (of 13.X). For the migration to the current version is no dump/restore required if already running a 13.X.