### PR TITLE
Adds virtualBackgroundsDisabled to documentation

### DIFF
--- a/_data/create.yml
+++ b/_data/create.yml
@@ -245,4 +245,4 @@
   required: false
   type: "Boolean"
   default: "false"
-  description: "Setting to <code class=\"language-plaintext highlighter-rouge\">true</code> will disable Virtual Backgrounds for all users in the meeting. (added 2.4)"
+  description: "Setting to <code class=\"language-plaintext highlighter-rouge\">true</code> will disable Virtual Backgrounds for all users in the meeting. (added 2.4.3)"

--- a/_data/create.yml
+++ b/_data/create.yml
@@ -240,3 +240,9 @@
   type: "Boolean"
   default: "false"
   description: "Setting to <code class=\"language-plaintext highlighter-rouge\">true</code> will allow moderators to close other users cameras in the meeting. (added 2.4)"
+
+- name: "virtualBackgroundsDisabled"
+  required: false
+  type: "Boolean"
+  default: "false"
+  description: "Setting to <code class=\"language-plaintext highlighter-rouge\">true</code> will disable Virtual Backgrounds for all users in the meeting. (added 2.4)"

--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -69,7 +69,7 @@ Updated in 2.4 (under development):
 
 - **getDefaultConfigXML** Removed, not used in HTML5 client
 - **setConfigXML** Removed, not used in HTML5 client
-- **create** - Added `meetingLayout`, `learningDashboardEnabled`, `learningDashboardCleanupDelayInMinutes`, `allowModsToEjectCameras`
+- **create** - Added `meetingLayout`, `learningDashboardEnabled`, `learningDashboardCleanupDelayInMinutes`, `allowModsToEjectCameras`, `virtualBackgroundsDisabled`
 - **join** - Added `role`, `excludeFromDashboard`
 
 # API Data Types


### PR DESCRIPTION
Includes documentation about the new /create param `virtualBackgroundsDisabled` sent in: https://github.com/bigbluebutton/bigbluebutton/pull/14075