### PR TITLE
feat(api): allowRequestsWithoutSession as a meeting create param

### DIFF
--- a/_data/create.yml
+++ b/_data/create.yml
@@ -240,3 +240,9 @@
   type: "Boolean"
   default: "false"
   description: "Setting to <code class=\"language-plaintext highlighter-rouge\">true</code> will allow moderators to close other users cameras in the meeting. (added 2.4)"
+
+- name: "allowRequestsWithoutSession"
+  required: false
+  type: "Boolean"
+  default: "false"
+  description: "Setting to <code class=\"language-plaintext highlighter-rouge\">true</code> will allow users to join meetings without session cookie's validation. (added 2.4)"

--- a/_data/create.yml
+++ b/_data/create.yml
@@ -245,4 +245,4 @@
   required: false
   type: "Boolean"
   default: "false"
-  description: "Setting to <code class=\"language-plaintext highlighter-rouge\">true</code> will allow users to join meetings without session cookie's validation. (added 2.4)"
+  description: "Setting to <code class=\"language-plaintext highlighter-rouge\">true</code> will allow users to join meetings without session cookie's validation. (added 2.4.3)"


### PR DESCRIPTION
Add a create meeting parameter to enable or disable the user's cookie
session requests.

Proposed at https://github.com/bigbluebutton/bigbluebutton/pull/14112