### PR TITLE
Fix missing hyphens in DDP_DEFAULT_CONNECTION_URL env variable.

### DIFF
--- a/_posts/admin/2022-01-27-clusterproxy.md
+++ b/_posts/admin/2022-01-27-clusterproxy.md
@@ -121,7 +121,7 @@ Each should have the following content:
 ```
 [Service]
 Environment=ROOT_URL=https://127.0.0.1/bbb-01/html5client
-Environment=DDP_DEFAULT_CONNECTION_URL=https://bbb01.example.com/bbb01/html5client
+Environment=DDP_DEFAULT_CONNECTION_URL=https://bbb-01.example.com/bbb-01/html5client
 ```
 
 Change the nginx `$bbb_loadbalancer_node` variable to the name of the load


### PR DESCRIPTION
While following and testing the proxy cluster setup from #352 I found a minor typo not matching the naming schema of the other configuration snippets.

Cc @danimo 