### PR TITLE
feat(webhooks): filter by eventID

### DIFF
--- a/_posts/dev/2015-04-05-webhooks.md
+++ b/_posts/dev/2015-04-05-webhooks.md
@@ -50,6 +50,7 @@ Hooks are permanently stored on redis and will enabled until the hook is explici
 | ----------- | ------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | callbackURL | Required            | String  | The URL that will receive a POST call with the events. The same URL cannot be registered more than once.                                      |
 | meetingID   | Optional            | String  | A `meetingID` to bind this hook to an specific meeting. If not informed, the hook will receive events for all meetings.                       |
+| eventID     | Optional            | String  | An `eventID` or a comma-separated `eventID` list to bind this hook to. If not informed, the hook will receive all events. (v2.5)              |
 | getRaw      | Optional            | Boolean | False by default. When getRaw=true, the POST call will contain the exact same message sent on redis, otherwise the message will be processed. |
 
 **Response when a hook is successfully registered**:


### PR DESCRIPTION
Follows the new `eventID` filter parameter included in https://github.com/bigbluebutton/bbb-webhooks/pull/3

Target: BugBlueButton version 2.5

Kudos @NaNgets