### PR TITLE
feat(api): user camera cap on create

### DIFF
--- a/_data/create.yml
+++ b/_data/create.yml
@@ -242,3 +242,9 @@
   type: "Boolean"
   default: "false"
   description: "Setting to <code class=\"language-plaintext highlighter-rouge\">true</code> will disable Virtual Backgrounds for all users in the meeting. (added 2.4.3)"
+
+- name: "userCameraCap"
+  required: false
+  type: "Number"
+  default: "3"
+  description: "Setting to <code class=\"language-plaintext highlighter-rouge\">0</code> will disable this threshold. Defines the max number of webcams a single user can share simultaneously. (added 2.4.5)"

--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -69,7 +69,7 @@ Updated in 2.4 (under development):
 
 - **getDefaultConfigXML** Removed, not used in HTML5 client
 - **setConfigXML** Removed, not used in HTML5 client
-- **create** - Added `meetingLayout`, `learningDashboardEnabled`, `learningDashboardCleanupDelayInMinutes`, `allowModsToEjectCameras`, `virtualBackgroundsDisabled`
+- **create** - Added `meetingLayout`, `learningDashboardEnabled`, `learningDashboardCleanupDelayInMinutes`, `allowModsToEjectCameras`, `virtualBackgroundsDisabled`, `userCameraCap`
 - **join** - Added `role`, `excludeFromDashboard`
 
 # API Data Types


### PR DESCRIPTION
Include `userCameraCap` API param on create and enforce both server and
client to control the number of simultaneous webcams an user can share.

Default set to 3.

Part of https://github.com/bigbluebutton/bigbluebutton/pull/14433