### PR TITLE
refactor(api): missing param on 2.4 changelog

### DIFF
--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -69,7 +69,7 @@ Updated in 2.4 (under development):
 
 - **getDefaultConfigXML** Removed, not used in HTML5 client
 - **setConfigXML** Removed, not used in HTML5 client
-- **create** - Added `meetingLayout`, `learningDashboardEnabled`, `learningDashboardCleanupDelayInMinutes`, `allowModsToEjectCameras`, `virtualBackgroundsDisabled`
+- **create** - Added `meetingLayout`, `learningDashboardEnabled`, `learningDashboardCleanupDelayInMinutes`, `allowModsToEjectCameras`, `virtualBackgroundsDisabled`, `allowRequestsWithoutSession`
 - **join** - Added `role`, `excludeFromDashboard`
 
 # API Data Types


### PR DESCRIPTION
Add `allowRequestsWithoutSession` to the API changelog.

Missing from https://github.com/bigbluebutton/bigbluebutton.github.io/pull/349