### PR TITLE
Add docs for param groups of /create

### DIFF
--- a/_data/create.yml
+++ b/_data/create.yml
@@ -244,6 +244,11 @@
   default: "3"
   description: "Setting to <code class=\"language-plaintext highlighter-rouge\">0</code> will disable this threshold. Defines the max number of webcams a single user can share simultaneously. (added 2.4.5)"
 
+- name: "groups"
+  required: false
+  type: "String"
+  description: "Pre-defined groups to automatically assign the students to a given breakout room.<br><b>Expected value:</b> Json with Array of groups.<br><b>Group properties:</b><br><ul><li><code class=\"language-plaintext highlighter-rouge\">id</code> - Number with group unique id.</li><li><code class=\"language-plaintext highlighter-rouge\">name</code> - String with name of the group <i>(optional)</i>.</li><li><code class=\"language-plaintext highlighter-rouge\">roster</code> - Array with objects of users ids. e.g: <code class=\"language-plaintext highlighter-rouge\">[{id:1235}]</code></li></ul><br>E.g:<br><code class=\"language-json highlighter-rouge\">[<br>{id:1,name:'GroupA',roster:[{id:1235}]},<br>{id:2,name:'GroupB',roster:[{id:2333},{id:2335}]},<br>{id:3,roster:[]}<br>]</code>"
+
 - name: "disabledFeatures"
   required: false
   type: "String"

--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -74,7 +74,7 @@ Updated in 2.4:
 
 Updated in 2.5:
 
-- **create** - Added `disabledFeatures`, removed `learningDashboardEnabled`
+- **create** - Added `groups`, `disabledFeatures`, removed `learningDashboardEnabled`
 
 # API Data Types
 


### PR DESCRIPTION
Add documentation for param `groups` of API `/create`, sent on  [#13678](https://github.com/bigbluebutton/bigbluebutton/pull/13678).

![image](https://user-images.githubusercontent.com/5660191/157057459-087e83a9-da36-4393-bb38-055c730bd869.png)
