### PR TITLE
Add meetingExpire options to API create doc

### DIFF
--- a/_data/create.yml
+++ b/_data/create.yml
@@ -261,6 +261,18 @@
   default: "0"
   description: "Setting to <code class=\"language-plaintext highlighter-rouge\">0</code> will disable this threshold. Defines the max number of webcams a meeting can have simultaneously. (added 2.5.0)"
 
+- name: "meetingExpireIfNoUserJoinedInMinutes"
+  required: false
+  type: "Number"
+  default: "5"
+  description: "Automatically end meeting if no user joined within a period of time after meeting created. (added 2.4.6)"
+
+- name: "meetingExpireWhenLastUserLeftInMinutes"
+  required: false
+  type: "Number"
+  default: "1"
+  description: "Number of minutes to automatically end meeting after last user left. (added 2.4.6)<br>Setting to <code class=\"language-plaintext highlighter-rouge\">0</code> will disable this function."
+
 - name: "groups"
   required: false
   type: "String"

--- a/_data/create.yml
+++ b/_data/create.yml
@@ -265,13 +265,13 @@
   required: false
   type: "Number"
   default: "5"
-  description: "Automatically end meeting if no user joined within a period of time after meeting created. (added 2.4.6)"
+  description: "Automatically end meeting if no user joined within a period of time after meeting created. (added 2.5)"
 
 - name: "meetingExpireWhenLastUserLeftInMinutes"
   required: false
   type: "Number"
   default: "1"
-  description: "Number of minutes to automatically end meeting after last user left. (added 2.4.6)<br>Setting to <code class=\"language-plaintext highlighter-rouge\">0</code> will disable this function."
+  description: "Number of minutes to automatically end meeting after last user left. (added 2.5)<br>Setting to <code class=\"language-plaintext highlighter-rouge\">0</code> will disable this function."
 
 - name: "groups"
   required: false

--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -69,7 +69,7 @@ Updated in 2.4:
 
 - **getDefaultConfigXML** Removed, not used in HTML5 client.
 - **setConfigXML** Removed, not used in HTML5 client.
-- **create** - Added `meetingLayout`, `learningDashboardEnabled`, `learningDashboardCleanupDelayInMinutes`, `allowModsToEjectCameras`, `virtualBackgroundsDisabled`, `allowRequestsWithoutSession`, `userCameraCap`.
+- **create** - Added `meetingLayout`, `learningDashboardEnabled`, `learningDashboardCleanupDelayInMinutes`, `allowModsToEjectCameras`, `virtualBackgroundsDisabled`, `allowRequestsWithoutSession`, `userCameraCap`, `meetingExpireIfNoUserJoinedInMinutes`, `meetingExpireWhenLastUserLeftInMinutes`.
 - **join** - Added `role`, `excludeFromDashboard`.
 
 Updated in 2.5:


### PR DESCRIPTION
Doc for this PR: [#14675](https://github.com/bigbluebutton/bigbluebutton/pull/14675)

API /create params:
- `meetingExpireIfNoUserJoinedInMinutes`
- `meetingExpireWhenLastUserLeftInMinutes`

![image](https://user-images.githubusercontent.com/5660191/160178914-9d7da6ab-c078-41c5-86b7-f65286c96281.png)
