### PR TITLE
Updated docs for constraints on create request parameters

### DIFF
--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -69,7 +69,10 @@ Updated in 2.4:
 
 - **getDefaultConfigXML** Removed, not used in HTML5 client.
 - **setConfigXML** Removed, not used in HTML5 client.
-- **create** - Added `meetingLayout`, `learningDashboardEnabled`, `learningDashboardCleanupDelayInMinutes`, `allowModsToEjectCameras`, `virtualBackgroundsDisabled`, `allowRequestsWithoutSession`, `userCameraCap`.
+- **create** 
+   - Added `meetingLayout`, `learningDashboardEnabled`, `learningDashboardCleanupDelayInMinutes`, `allowModsToEjectCameras`, `virtualBackgroundsDisabled`, `allowRequestsWithoutSession`, `userCameraCap`.
+   - `name`, `attendeePW`, and `moderatorPW` must be between 2 and 64 characters long
+   - `meetingID` must be between 2 and 256 characters long and cannot contain commas
 - **join** - Added `role`, `excludeFromDashboard`.
 
 Updated in 2.5:


### PR DESCRIPTION
Added documentation for constraints on create requests that were added in 2.4 with the validation changes.