### PR TITLE
Improve description of max concurrent users limit

### DIFF
--- a/_posts/support/2015-04-05-faq.md
+++ b/_posts/support/2015-04-05-faq.md
@@ -419,9 +419,9 @@ In short, if the user is having any problems (such as audio is garbled or they a
 
 ## How many simultaneous users can BigBlueButton support
 
-As a rule of thumb, if your BigBlueButton server meets the [minimum requirements](https://docs.bigbluebutton.org/2.4/install.html#minimum-server-requirements), the server should be able to support 150 simultaneous users, such as 3 simultaneous sessions of 50 users, 6 x 25, etc.
+As a rule of thumb, if your BigBlueButton server meets the [minimum requirements](https://docs.bigbluebutton.org/2.4/install.html#minimum-server-requirements), the server should be able to support 150 simultaneous users, such as 3 simultaneous sessions of 50 users, 6 x 25, etc. More concurrent users can be supported by using better servers and/or by using [load balancers](https://github.com/blindsidenetworks/scalelite#scalelite) for clusters of BigBlueButton servers.
 
-As of BigBlueButton 2.3, we recommend no single sessions exceed one hundred and fifty users (150) users.
+As of BigBlueButton 2.4, we recommend no single sessions exceed one hundred and fifty users (150) users.
 
 Members of our community periodically host stress tests for BigBlueButton, which gives others a data point on what a particular server was able to handle. Take any stress test with a grain of salt. There are many variables at play:
 
@@ -439,7 +439,7 @@ If you are unsure of how many users your server will support, we **strongly** re
 
 To test your own server, have five people login and have each open multiple browser tabs, each tab logging into BigBlueButton and joining the audio conference. With 5 friends, you can simulate 10, 20, 30, etc. users. You'll find once the CPU reaches 80%, the audio starts to degrade. When the audio starts to degrade, you've found the maximum number of users for your server.
 
-If you also want to monitor, there are a number of [tools](https://www.ubuntugeek.com/bandwidth-monitoring-tools-for-ubuntu-users.html) for Ubuntu.
+For monitoring the server, please take a look at the [monitoring section](https://docs.bigbluebutton.org/admin/monitoring.html) or use other generic monitoring [tools](https://www.ubuntugeek.com/bandwidth-monitoring-tools-for-ubuntu-users.html) for Ubuntu Linux.
 
 Additionally, you can see [commercial support](https://bigbluebutton.org/commercial-support/) for help in stress testing your server.
 


### PR DESCRIPTION
Makes clear that 150 concurrent users is not the limit of BigBlueButton. Links to Scalelite and mentions cluster setup for supporting more users.

Also links the monitoring section for monitoring the server.