### PR TITLE
add a note about bbb-webhooks for update 2.3 → 2.4

### DIFF
--- a/_posts/2.4/2021-05-01-install.md
+++ b/_posts/2.4/2021-05-01-install.md
@@ -324,6 +324,8 @@ if you are upgrading BigBlueButton 2.2, we recommend setting up a new Ubuntu 18.
 
 if you are upgrading BigBlueButton 2.3, you can simply re-run the bbb-install command you used for 2.3 but replacing the repository `bionic-230` with `bionic-240`.
 
+After that, if the command `sudo bbb-conf --check` complains about a “Webhooks API Shared Secret mismatch”, reinstall the webhooks: `sudo apt-get install --reinstall bbb-webhooks`
+
 <!-- TODO double check this on a server with recordings -->
 
 ## Restart your server


### PR DESCRIPTION
The webhooks updating process doesn't check if the secrets match. Reinstalling the the package `bbb-webhooks` forces this check (and uses the correct secret).