### PR TITLE
Fix doc about when XML response is returned in Api /JOIN

### DIFF
--- a/_data/join.yml
+++ b/_data/join.yml
@@ -51,7 +51,7 @@
 - name: "redirect"
   required: false
   type: "String"
-  description: "The default behaviour of the JOIN API is to redirect the browser to the Flash client when the JOIN call succeeds. There have been requests if it’s possible to embed the Flash client in a “container” page and that the client starts as a hidden DIV tag which becomes visible on the successful JOIN. Setting this variable to FALSE will not redirect the browser but returns an XML instead whether the JOIN call has succeeded or not. The third party app is responsible for displaying the client to the user."
+  description: "The default behaviour of the JOIN API is to redirect the browser to the HTML5 client when the JOIN call succeeds. There have been requests if it’s possible to embed the HTML5 client in a “container” page and that the client starts as a hidden DIV tag which becomes visible on the successful JOIN. Setting this variable to FALSE will not redirect the browser but returns an XML instead whether the JOIN call has succeeded or not. The third party app is responsible for displaying the client to the user."
 
 - name: "clientURL"
   required: false

--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -518,7 +518,7 @@ http&#58;//yourserver.com/bigbluebutton/api/join?[parameters]&checksum=[checksum
 
 **Example Response:**
 
-There is only an XML response for this call if the `redirect` parameter is set to `true`. You should simply redirect the user to the call URL, and they will be entered into the meeting.
+There is a XML response for this call only when the `redirect` parameter is set to `false`. You should simply redirect the user to the call URL, and they will be entered into the meeting.
 
 ```xml
 <response>


### PR DESCRIPTION
As pointed out in https://github.com/bigbluebutton/bigbluebutton.github.io/issues/394.

This PR fix two informations:
- The XML is returned when `redirect` param is `FALSE`.
- Replace `Flash` by `HTML5` in the `redirect` description.