### PR TITLE
Create "/etc/bigbluebutton/nginx/" before putting files into

### DIFF
--- a/_posts/admin/2019-02-14-customize.md
+++ b/_posts/admin/2019-02-14-customize.md
@@ -1382,6 +1382,8 @@ yq w -i $HTML5_CONFIG public.clientLog.external.url     "$PROTOCOL://$HOST/html5
 yq w -i $HTML5_CONFIG public.app.askForFeedbackOnLogout true
 chown meteor:meteor $HTML5_CONFIG
 
+mkdir -p /etc/bigbluebutton/nginx/
+
 cat > /etc/bigbluebutton/nginx/html5-client-log.nginx << HERE
 location /html5log {
         access_log /var/log/nginx/html5-client.log postdata;


### PR DESCRIPTION
"/etc/bigbluebutton/nginx/" does not exist in a 2.5.0 installation. It should be created therefore.
See also https://github.com/bigbluebutton/bigbluebutton/issues/15193