### PR TITLE
Get URL from /etc/bigbluebutton/bbb-web.properties

### DIFF
--- a/_posts/admin/2019-02-14-customize.md
+++ b/_posts/admin/2019-02-14-customize.md
@@ -1371,9 +1371,9 @@ To enable the feedback and it's logging to your server, run the following script
 ```bash
 #!/bin/bash
 
-HOST=$(cat /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}')
+HOST=$(cat /etc/bigbluebutton/bbb-web.properties | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}')
 HTML5_CONFIG=/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
-PROTOCOL=$(cat /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties | grep -v '#' | grep '^bigbluebutton.web.serverURL' | sed 's/.*\(http[s]*\).*/\1/')
+PROTOCOL=$(cat /etc/bigbluebutton/bbb-web.properties | grep -v '#' | grep '^bigbluebutton.web.serverURL' | sed 's/.*\(http[s]*\).*/\1/')
 
 apt-get install -y nginx-full
 


### PR DESCRIPTION
For me, the value in /etc/bigbluebutton/bbb-web.properties was the hostname while it was the IP in /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties. I don't know it this is a server-specific issue or something new in 2.5