### PR TITLE
Add nginx route for guest lobby in cluster setup

### DIFF
--- a/_posts/admin/2022-01-27-clusterproxy.md
+++ b/_posts/admin/2022-01-27-clusterproxy.md
@@ -148,6 +148,16 @@ location /bbb-01/html5client/locales {
 **Note:** It is important that the location configuration is equal between the
 BigBlueButton server and the proxy.
 
+Add a route for the locales handler for the guest lobby. The guest lobby is served directly from the BBB node.
+
+```
+# /etc/bigbluebutton/nginx/bbb-html5.nginx
+location =/html5client/locale {
+  return 301 /bbb-01$request_uri;
+}
+```
+
+
 Restart BigBlueButton:
 
 ```shell

--- a/_posts/admin/2022-01-27-clusterproxy.md
+++ b/_posts/admin/2022-01-27-clusterproxy.md
@@ -93,7 +93,7 @@ Add these options to `/etc/bigbluebutton/bbb-web.properties`:
 defaultHTML5ClientUrl=https://bbb-proxy.example.com/bbb-01/html5client/join
 presentationBaseURL=https://bbb-01.example.com/bigbluebutton/presentation
 accessControlAllowOrigin=https://bbb-proxy.example.com
-defaultGuestWaitURL=https://bbb-proxy.example.com/bbb-01/html5client/guestWait
+defaultGuestWaitURL=https://bbb-01.example.com/bbb-01/html5client/guestWait
 ```
 
 Add the following options to `/etc/bigbluebutton/bbb-html5.yml`:


### PR DESCRIPTION
The path in `guest-wait.html` is hard coded and is not aware of cluster
setup. Thats not a real problem because we can just add a redirect in
nginx.

It is a different approach than in #379