### PR TITLE
FAQ: Correct link to the v2.5 minimum requirements

### DIFF
--- a/_posts/support/2015-04-05-faq.md
+++ b/_posts/support/2015-04-05-faq.md
@@ -419,7 +419,7 @@ In short, if the user is having any problems (such as audio is garbled or they a
 
 ## How many simultaneous users can BigBlueButton support
 
-As a rule of thumb, if your BigBlueButton server meets the [minimum requirements](https://docs.bigbluebutton.org/2.4/install.html#minimum-server-requirements), the server should be able to support 150 simultaneous users, such as 3 simultaneous sessions of 50 users, 6 x 25, etc. More concurrent users can be supported by using better servers and/or by using [load balancers](https://github.com/blindsidenetworks/scalelite#scalelite) for clusters of BigBlueButton servers.
+As a rule of thumb, if your BigBlueButton server meets the [minimum requirements](https://docs.bigbluebutton.org/2.5/install.html#minimum-server-requirements), the server should be able to support 150 simultaneous users, such as 3 simultaneous sessions of 50 users, 6 x 25, etc. More concurrent users can be supported by using better servers and/or by using [load balancers](https://github.com/blindsidenetworks/scalelite#scalelite) for clusters of BigBlueButton servers.
 
 As of BigBlueButton 2.4, we recommend no single sessions exceed one hundred and fifty users (150) users.
 


### PR DESCRIPTION
Changed the link to the minimum requirements section of the install instructions from pointing at version 2.4 to now pointing at version 2.5 in the FAQ.