### PR TITLE
Fix test plan link

### DIFF
--- a/_posts/2.6/2022-02-10-release-tests.md
+++ b/_posts/2.6/2022-02-10-release-tests.md
@@ -1444,7 +1444,7 @@ Note :
 
 3. The Popup Alerts for Chat are now Disabled/Enabled.
 
-#### D. Application Language [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/settings/settings.spec.js)
+#### D. Application Language [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/options/options.spec.js)
 
 (Inside "Application" section of the Settings modal)
 


### PR DESCRIPTION
Minor fix in the test plan link on v2.6 for an automated test