### PR TITLE
[fix] good URL for referencing BBB Events

### DIFF
--- a/_posts/dev/2015-04-05-webhooks.md
+++ b/_posts/dev/2015-04-05-webhooks.md
@@ -12,7 +12,7 @@ receive HTTP POST requests.
 These web hooks allow 3rd party applications to subscribe to different events that happen during a
 BigBlueButton session. An event can be: a meeting was created, a user joined, a new presentation was
 uploaded, a user left, a recording is being processed, and many others. You can see the entire list
-of events that generate web hooks calls in [this file](https://github.com/bigbluebutton/bigbluebutton/blob/v2.0.x-release/bbb-webhooks/messageMapping.js#L187).
+of events that generate web hooks calls in [this file](https://github.com/bigbluebutton/bbb-webhooks/blob/develop/messageMapping.js).
 
 Installation
 ------------


### PR DESCRIPTION
I've updated documentation, because I've stumbled upon a 404 clicking on the link furnished in https://docs.bigbluebutton.org/dev/webhooks.html

Hopefully I did good