### PR TITLE
Use more appropiate wording / fix typo

### DIFF
--- a/_posts/dev/2015-04-04-recording.md
+++ b/_posts/dev/2015-04-04-recording.md
@@ -156,7 +156,7 @@ Administration:
                                        (Only for Matterhorn Integration)
 ```
 
-### Usefull Configs
+### Useful settings
 
 | Name                    | Path (file)                                                 | Description |
 | :-----------------------| :-----------------------------------------------------------| :-----------|


### PR DESCRIPTION
The table does not refer to complete config files, but only to two settings, so refering to those as "settings" rather as "Configs" seems to be more appropiate.

Fix typo: "useful" is only written with one "l".