### PR TITLE
[adjust-endpoint-post-call] Adjusting create and end POST options

### DIFF
--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -297,7 +297,6 @@ curl --request POST \
   --data welcome=Welcome \
   --data allowStartStopRecording=true \
   --data attendeePW=ap \
-  --data name=Test+Meeting \
   --data autoStartRecording=false \
   --data meetingID=random-1730297 \
   --data moderatorPW=mp \

--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -287,6 +287,38 @@ http&#58;//yourserver.com/bigbluebutton/api/create?[parameters]&checksum=[checks
 </response>
 ```
 
+### POST request
+You can also include a payload in the request, it may be usefull in cases where some of the query parameters are big enough to exceed the maximum number of characters in URLs. BigBlueButton supports a POST request where the parameters that usually would be passed in the URL, can be sent through the body, see example below:
+
+```bash
+curl --request POST \
+  --url https://<your-host>/bigbluebutton/api/create \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data welcome=Welcome \
+  --data allowStartStopRecording=true \
+  --data attendeePW=ap \
+  --data name=Test+Meeting \
+  --data autoStartRecording=false \
+  --data meetingID=random-1730297 \
+  --data moderatorPW=mp \
+  --data name=random-1730297 \
+  --data record=false \
+  --data voiceBridge=71296 \
+  --data checksum=1234;
+```
+
+It will be further explored in the next section the possibility of sending other data types in the payload as well. 
+
+One other think to pay attention is to not include any of the parameters in both the URL and the body, or else it will pop a `checksum does not match` error:
+
+```xml
+<response>
+<returncode>FAILED</returncode>
+<messageKey>checksumError</messageKey>
+<message>Checksums do not match</message>
+</response>
+```
+
 ### Pre-upload Slides
 
 You can upload slides within the create call. If you do this, the BigBlueButton server will immediately download and process the slides.
@@ -515,6 +547,18 @@ Use this to forcibly end a meeting and kick all participants out of the meeting.
     A request to end the meeting was sent.  Please wait a few seconds, and then use the getMeetingInfo or isMeetingRunning API calls to verify that it was ended
   </message>
 </response>
+```
+
+### POST request 
+Just like the [create request](#post-request), you can send a POST to end the meeting, the syntax is pretty much the same, see example below:
+
+```bash
+curl --request POST \
+	--url https://<your-host>/bigbluebutton/api/end \
+	--header 'Content-Type: application/x-www-form-urlencoded' \
+	--data meetingID=Test+Meeting \
+	--data password=mp \
+	--data checksum=1234
 ```
 
 **IMPORTANT NOTE:** You should note that when you call end meeting, it is simply sending a request to the backend (Red5) server that is handling all the conference traffic. That backend server will immediately attempt to send every connected client a logout event, kicking them from the meeting. It will then disconnect them, and the meeting will be ended. However, this may take several seconds, depending on network conditions. Therefore, the end meeting call will return a success as soon as the request is sent. But to be sure that it completed, you should then check back a few seconds later by using the `getMeetingInfo` or `isMeetingRunning` calls to verify that all participants have left the meeting and that it successfully ended.


### PR DESCRIPTION
## What does this PR do? 

Adjust documentation for endpoints that support the POST method request just for sending common parameters, that is the case for `create` and `end`. 

Docs for create
![image](https://user-images.githubusercontent.com/69865537/196445362-ced7c479-fe23-49dc-bfbe-6318b2ade5f8.png)

Docs for end
![image](https://user-images.githubusercontent.com/69865537/196445029-b76f60ef-0975-43e6-91ba-53fd8bf7e8b0.png)

Should anything else related be tuned,  please contact.