### PR TITLE
Naming of NGINX

### DIFF
--- a/_posts/2.4/2021-05-01-architecture.md
+++ b/_posts/2.4/2021-05-01-architecture.md
@@ -8,7 +8,7 @@ redirect_from:
 order: 4
 ---
 
-BigBlueButton is built upon a solid foundation of underlying components, including NginX, FreeSWITCH, Kurento, Redis, Node.js, React.js, and others.
+BigBlueButton is built upon a solid foundation of underlying components, including NGINX, FreeSWITCH, Kurento, Redis, Node.js, React.js, and others.
 
 This page describes the overall architecture of BigBlueButton and how these components work together.
 

--- a/_posts/2.4/2021-09-22-dev.md
+++ b/_posts/2.4/2021-09-22-dev.md
@@ -67,7 +67,7 @@ Consider using a Docker setup for a development environment - https://github.com
 
 <!-- TODO replace user ubuntu with user bigbluebutton -->
 
-**Important:** Make sure you create another user such as "ubuntu" to avoid running into permission errors such as Nginx 403 Forbidden error or [error-null-while-compiling-resource-bundles-under-linux-with-hudson](https://stackoverflow.com/questions/3863066/error-null-while-compiling-resource-bundles-under-linux-with-hudson).
+**Important:** Make sure you create another user such as "ubuntu" to avoid running into permission errors such as NGINX 403 Forbidden error or [error-null-while-compiling-resource-bundles-under-linux-with-hudson](https://stackoverflow.com/questions/3863066/error-null-while-compiling-resource-bundles-under-linux-with-hudson).
 
 Do not run commands as the root user and only use sudo when instructed to.
 
@@ -255,7 +255,7 @@ You can access https://BBB_DOMAIN , and you will be able to join meetings.
 
 A bit of context is needed to fully explain what the HTML5 client is, why it has server component, what the architecture is, and only then how to make a change and re-deploy.
 
-The HTML5 client in BigBlueButton is build using the framework [Meteor](https://meteor.com). Meteor wraps around a NodeJS server component, MongoDB server database, React frontend user interface library and MiniMongo frontend instance of MongoDB storing a subset of MongoDB's data. When deployed, these same components are split into independently running pieces - NodeJS instance, MongoDB database and a browser optimized client files served by NginX. There is no "Meteor" in a production deployment, but rather separate components.
+The HTML5 client in BigBlueButton is build using the framework [Meteor](https://meteor.com). Meteor wraps around a NodeJS server component, MongoDB server database, React frontend user interface library and MiniMongo frontend instance of MongoDB storing a subset of MongoDB's data. When deployed, these same components are split into independently running pieces - NodeJS instance, MongoDB database and a browser optimized client files served by NGINX. There is no "Meteor" in a production deployment, but rather separate components.
 
 <!--
 TODO: add diagram
@@ -315,11 +315,11 @@ $ NODE_ENV=production npm start
 
 In certain cases when making changes that span multiple BigBlueButton components you would want to ensure that the changes work well with the multiple different `NodeJS` processes.
 
-You can deploy locally your modified version of the HTML5 client source using the script [bigbluebutton-html5/deploy_to_usr_share.sh](https://github.com/bigbluebutton/bigbluebutton/blob/v2.4.x-release/bigbluebutton-html5/deploy_to_usr_share.sh) - which deploys your [customized] bigbluebutton-html5/\* code as locally running `bbb-html5` package (production mode, requiring the `poolhtml5servers` NginX rule). Make sure to read through the script to understand what it does prior to using it.
+You can deploy locally your modified version of the HTML5 client source using the script [bigbluebutton-html5/deploy_to_usr_share.sh](https://github.com/bigbluebutton/bigbluebutton/blob/v2.4.x-release/bigbluebutton-html5/deploy_to_usr_share.sh) - which deploys your [customized] bigbluebutton-html5/\* code as locally running `bbb-html5` package (production mode, requiring the `poolhtml5servers` NGINX rule). Make sure to read through the script to understand what it does prior to using it.
 
-## Switch NginX to redirect requests to Meteor
+## Switch NGINX to redirect requests to Meteor
 
-When you are running bbb-html5 from package (i.e. in production mode) NginX needs to be able to point client sessions to a bbb-html5-frontend instance from the pool. However, in development mode (i.e. running Meteor via `npm start`), we only have one process, rather than a pool. We need to tweak the NginX configuration so that client sessions are only pointed to port `4100` where Meteor is running.
+When you are running bbb-html5 from package (i.e. in production mode) NGINX needs to be able to point client sessions to a bbb-html5-frontend instance from the pool. However, in development mode (i.e. running Meteor via `npm start`), we only have one process, rather than a pool. We need to tweak the NGINX configuration so that client sessions are only pointed to port `4100` where Meteor is running.
 
 You would want to make a change in `/etc/bigbluebutton/nginx/bbb-html5.nginx` to use 4100 port rather than the pool.
 
@@ -341,19 +341,19 @@ location ~ ^/html5client/ {
   ...
 ```
 
-After this change, reload NginX's configuration with `sudo systemctl reload nginx`
+After this change, reload NGINX's configuration with `sudo systemctl reload nginx`
 
-A symptom of running `npm start` with the incompatible `poolhtml5servers` NginX configuration is seeing `It looks like you are trying to access MongoDB over HTTP on the native driver port.` and `Uncaught SyntaxError: Unexpected Identifier`
+A symptom of running `npm start` with the incompatible `poolhtml5servers` NGINX configuration is seeing `It looks like you are trying to access MongoDB over HTTP on the native driver port.` and `Uncaught SyntaxError: Unexpected Identifier`
 
 When you switch back to running the `bbb-html5` packaged version you would want to revert your change so the `poolhtml5servers` are used for spreading the load of the client sessions.
 
-### Switch NginX static resource requests to Meteor
+### Switch NGINX static resource requests to Meteor
 
-Locales requests are served by NginX by default, but you may want to disable that feature in development mode (if you want to be able to edit the files located in `/public/locales` and see the changes being applied).
+Locales requests are served by NGINX by default, but you may want to disable that feature in development mode (if you want to be able to edit the files located in `/public/locales` and see the changes being applied).
 
 You would want to make a change in `/etc/bigbluebutton/nginx/bbb-html5.nginx` in the lines related to locales.
 
-The default - used for production mode (locales files will be served by NginX):
+The default - used for production mode (locales files will be served by NGINX):
 
 ```
   location /html5client/locales {
@@ -369,7 +369,7 @@ Development mode (locales files will be served by Meteor):
   #}
 ```
 
-After this change, reload NginX's configuration with `sudo systemctl reload nginx`
+After this change, reload NGINX's configuration with `sudo systemctl reload nginx`
 
 ## Audio configuration for development environment
 
@@ -604,9 +604,9 @@ dpkg -i ./target/bbb-fsesl-akka_<tab>.deb
 
 # Troubleshooting
 
-## Welcome to Nginx page
+## Welcome to NGINX page
 
-If you get the "Welcome to Nginx" page. Check if bigbluebutton is enabled in nginx. You should see **bigbluebutton** in `/etc/nginx/sites-enabled`.
+If you get the "Welcome to NGINX" page. Check if bigbluebutton is enabled in nginx. You should see **bigbluebutton** in `/etc/nginx/sites-enabled`.
 
 If not, enable it.
 

--- a/_posts/2.5/2021-09-22-dev.md
+++ b/_posts/2.5/2021-09-22-dev.md
@@ -263,7 +263,7 @@ You can access https://BBB_DOMAIN , and you will be able to join meetings.
 
 A bit of context is needed to fully explain what the HTML5 client is, why it has server component, what the architecture is, and only then how to make a change and re-deploy.
 
-The HTML5 client in BigBlueButton is build using the framework [Meteor](https://meteor.com). Meteor wraps around a NodeJS server component, MongoDB server database, React frontend user interface library and MiniMongo frontend instance of MongoDB storing a subset of MongoDB's data. When deployed, these same components are split into independently running pieces - NodeJS instance, MongoDB database and a browser optimized client files served by NginX. There is no "Meteor" in a production deployment, but rather separate components.
+The HTML5 client in BigBlueButton is build using the framework [Meteor](https://meteor.com). Meteor wraps around a NodeJS server component, MongoDB server database, React frontend user interface library and MiniMongo frontend instance of MongoDB storing a subset of MongoDB's data. When deployed, these same components are split into independently running pieces - NodeJS instance, MongoDB database and a browser optimized client files served by NGINX. There is no "Meteor" in a production deployment, but rather separate components.
 
 <!--
 TODO: add diagram
@@ -317,11 +317,11 @@ $ NODE_ENV=production npm start
 
 In certain cases when making changes that span multiple BigBlueButton components you would want to ensure that the changes work well with the multiple different `NodeJS` processes.
 
-You can deploy locally your modified version of the HTML5 client source using the script [bigbluebutton-html5/deploy_to_usr_share.sh](https://github.com/bigbluebutton/bigbluebutton/blob/v2.5.x-release/bigbluebutton-html5/deploy_to_usr_share.sh) - which deploys your [customized] bigbluebutton-html5/\* code as locally running `bbb-html5` package (production mode, requiring the `poolhtml5servers` NginX rule). Make sure to read through the script to understand what it does prior to using it.
+You can deploy locally your modified version of the HTML5 client source using the script [bigbluebutton-html5/deploy_to_usr_share.sh](https://github.com/bigbluebutton/bigbluebutton/blob/v2.5.x-release/bigbluebutton-html5/deploy_to_usr_share.sh) - which deploys your [customized] bigbluebutton-html5/\* code as locally running `bbb-html5` package (production mode, requiring the `poolhtml5servers` NGINX rule). Make sure to read through the script to understand what it does prior to using it.
 
-## Switch NginX to redirect requests to Meteor
+## Switch NGINX to redirect requests to Meteor
 
-When you are running bbb-html5 from package (i.e. in production mode) NginX needs to be able to point client sessions to a bbb-html5-frontend instance from the pool. However, in development mode (i.e. running Meteor via `npm start`), we only have one process, rather than a pool. We need to tweak the NginX configuration so that client sessions are only pointed to port `4100` where Meteor is running.
+When you are running bbb-html5 from package (i.e. in production mode) NGINX needs to be able to point client sessions to a bbb-html5-frontend instance from the pool. However, in development mode (i.e. running Meteor via `npm start`), we only have one process, rather than a pool. We need to tweak the NGINX configuration so that client sessions are only pointed to port `4100` where Meteor is running.
 
 You would want to make a change in `/etc/bigbluebutton/nginx/bbb-html5.nginx` to use 4100 port rather than the pool.
 
@@ -343,19 +343,19 @@ location ~ ^/html5client/ {
   ...
 ```
 
-After this change, reload NginX's configuration with `sudo systemctl reload nginx`
+After this change, reload NGINX's configuration with `sudo systemctl reload nginx`
 
-A symptom of running `npm start` with the incompatible `poolhtml5servers` NginX configuration is seeing `It looks like you are trying to access MongoDB over HTTP on the native driver port.` and `Uncaught SyntaxError: Unexpected Identifier`
+A symptom of running `npm start` with the incompatible `poolhtml5servers` NGINX configuration is seeing `It looks like you are trying to access MongoDB over HTTP on the native driver port.` and `Uncaught SyntaxError: Unexpected Identifier`
 
 When you switch back to running the `bbb-html5` packaged version you would want to revert your change so the `poolhtml5servers` are used for spreading the load of the client sessions.
 
-### Switch NginX static resource requests to Meteor
+### Switch NGINX static resource requests to Meteor
 
-Locales requests are served by NginX by default, but you may want to disable that feature in development mode (if you want to be able to edit the files located in `/public/locales` and see the changes being applied).
+Locales requests are served by NGINX by default, but you may want to disable that feature in development mode (if you want to be able to edit the files located in `/public/locales` and see the changes being applied).
 
 You would want to make a change in `/etc/bigbluebutton/nginx/bbb-html5.nginx` in the lines related to locales.
 
-The default - used for production mode (locales files will be served by NginX):
+The default - used for production mode (locales files will be served by NGINX):
 
 ```
   location /html5client/locales {
@@ -371,7 +371,7 @@ Development mode (locales files will be served by Meteor):
   #}
 ```
 
-After this change, reload NginX's configuration with `sudo systemctl reload nginx`
+After this change, reload NGINX's configuration with `sudo systemctl reload nginx`
 
 ## Audio configuration for development environment
 

--- a/_posts/2.6/2021-09-22-dev.md
+++ b/_posts/2.6/2021-09-22-dev.md
@@ -255,7 +255,7 @@ You can access https://BBB_DOMAIN , and you will be able to join meetings.
 
 A bit of context is needed to fully explain what the HTML5 client is, why it has server component, what the architecture is, and only then how to make a change and re-deploy.
 
-The HTML5 client in BigBlueButton is build using the framework [Meteor](https://meteor.com). Meteor wraps around a NodeJS server component, MongoDB server database, React frontend user interface library and MiniMongo frontend instance of MongoDB storing a subset of MongoDB's data. When deployed, these same components are split into independently running pieces - NodeJS instance, MongoDB database and a browser optimized client files served by NginX. There is no "Meteor" in a production deployment, but rather separate components.
+The HTML5 client in BigBlueButton is build using the framework [Meteor](https://meteor.com). Meteor wraps around a NodeJS server component, MongoDB server database, React frontend user interface library and MiniMongo frontend instance of MongoDB storing a subset of MongoDB's data. When deployed, these same components are split into independently running pieces - NodeJS instance, MongoDB database and a browser optimized client files served by NGINX. There is no "Meteor" in a production deployment, but rather separate components.
 
 <!--
 TODO: add diagram
@@ -309,11 +309,11 @@ $ NODE_ENV=production npm start
 
 In certain cases when making changes that span multiple BigBlueButton components you would want to ensure that the changes work well with the multiple different `NodeJS` processes.
 
-You can deploy locally your modified version of the HTML5 client source using the script [bigbluebutton-html5/deploy_to_usr_share.sh](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-html5/deploy_to_usr_share.sh) - which deploys your [customized] bigbluebutton-html5/\* code as locally running `bbb-html5` package (production mode, requiring the `poolhtml5servers` NginX rule). Make sure to read through the script to understand what it does prior to using it.
+You can deploy locally your modified version of the HTML5 client source using the script [bigbluebutton-html5/deploy_to_usr_share.sh](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-html5/deploy_to_usr_share.sh) - which deploys your [customized] bigbluebutton-html5/\* code as locally running `bbb-html5` package (production mode, requiring the `poolhtml5servers` NGINX rule). Make sure to read through the script to understand what it does prior to using it.
 
-## Switch NginX to redirect requests to Meteor
+## Switch NGINX to redirect requests to Meteor
 
-When you are running bbb-html5 from package (i.e. in production mode) NginX needs to be able to point client sessions to a bbb-html5-frontend instance from the pool. However, in development mode (i.e. running Meteor via `npm start`), we only have one process, rather than a pool. We need to tweak the NginX configuration so that client sessions are only pointed to port `4100` where Meteor is running.
+When you are running bbb-html5 from package (i.e. in production mode) NGINX needs to be able to point client sessions to a bbb-html5-frontend instance from the pool. However, in development mode (i.e. running Meteor via `npm start`), we only have one process, rather than a pool. We need to tweak the NGINX configuration so that client sessions are only pointed to port `4100` where Meteor is running.
 
 You would want to make a change in `/etc/bigbluebutton/nginx/bbb-html5.nginx` to use 4100 port rather than the pool.
 
@@ -335,19 +335,19 @@ location ~ ^/html5client/ {
   ...
 ```
 
-After this change, reload NginX's configuration with `sudo systemctl reload nginx`
+After this change, reload NGINX's configuration with `sudo systemctl reload nginx`
 
-A symptom of running `npm start` with the incompatible `poolhtml5servers` NginX configuration is seeing `It looks like you are trying to access MongoDB over HTTP on the native driver port.` and `Uncaught SyntaxError: Unexpected Identifier`
+A symptom of running `npm start` with the incompatible `poolhtml5servers` NGINX configuration is seeing `It looks like you are trying to access MongoDB over HTTP on the native driver port.` and `Uncaught SyntaxError: Unexpected Identifier`
 
 When you switch back to running the `bbb-html5` packaged version you would want to revert your change so the `poolhtml5servers` are used for spreading the load of the client sessions.
 
-### Switch NginX static resource requests to Meteor
+### Switch NGINX static resource requests to Meteor
 
-Locales requests are served by NginX by default, but you may want to disable that feature in development mode (if you want to be able to edit the files located in `/public/locales` and see the changes being applied).
+Locales requests are served by NGINX by default, but you may want to disable that feature in development mode (if you want to be able to edit the files located in `/public/locales` and see the changes being applied).
 
 You would want to make a change in `/etc/bigbluebutton/nginx/bbb-html5.nginx` in the lines related to locales.
 
-The default - used for production mode (locales files will be served by NginX):
+The default - used for production mode (locales files will be served by NGINX):
 
 ```
   location /html5client/locales {
@@ -363,7 +363,7 @@ Development mode (locales files will be served by Meteor):
   #}
 ```
 
-After this change, reload NginX's configuration with `sudo systemctl reload nginx`
+After this change, reload NGINX's configuration with `sudo systemctl reload nginx`
 
 ## Audio configuration for development environment
 
@@ -614,9 +614,9 @@ to begin exporting presentations with annotations.
 
 # Troubleshooting
 
-## Welcome to Nginx page
+## Welcome to NGINX page
 
-If you get the "Welcome to Nginx" page. Check if bigbluebutton is enabled in nginx. You should see **bigbluebutton** in `/etc/nginx/sites-enabled`.
+If you get the "Welcome to NGINX" page. Check if bigbluebutton is enabled in nginx. You should see **bigbluebutton** in `/etc/nginx/sites-enabled`.
 
 If not, enable it.
 


### PR DESCRIPTION
This changes the spelling of NGINX in a number of places. Previously, the spelling NginX was used at a number of places. A spelling which is never used at the upstream project. The NGINX project always uses a lowercase `x` or writes its name in all caps.