### PR TITLE
Adds bbb-pads config override info

### DIFF
--- a/_posts/admin/2015-04-04-configuration-files.md
+++ b/_posts/admin/2015-04-04-configuration-files.md
@@ -27,6 +27,7 @@ Starting with BigBlueButton 2.3 many of the configuration files have local overr
 | /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml              | /etc/bigbluebutton/bbb-webrtc-sfu/production.yml | Arrays are merged by replacement                                                 |
 | /etc/bigbluebutton/recording/recording.yml                              | /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml |
 | /etc/bigbluebutton/recording/presentation.yml                           | /usr/local/bigbluebutton/core/scripts/presentation.yml/presentation.yml |
+| /usr/local/bigbluebutton/bbb-pads/config/settings.json                  | /etc/bigbluebutton/bbb-pads.json                 | Arrays are merged by replacement                                                 |
 
 <br /><br />
 


### PR DESCRIPTION
Adds the bbb-pads to the local overrides for configuration settings' table:

![image](https://user-images.githubusercontent.com/32987232/201183578-c9fb90b3-e5ec-478b-a7b9-d4223ddb9ae6.png)

Depends on:
- https://github.com/bigbluebutton/bbb-pads/pull/19