### PR TITLE
FreeSWITCH: mention setting `local-network-acl` to `none` when behind…

### DIFF
--- a/_posts/admin/2019-02-14-configure-firewall.md
+++ b/_posts/admin/2019-02-14-configure-firewall.md
@@ -266,6 +266,20 @@ to
     <param name="ext-sip-ip" value="$${external_sip_ip}"/>
 ```
 
+In the same file make sure to change
+
+```xml
+    <param name="local-network-acl" value="localnet.auto"/>
+```
+
+to
+
+```xml
+    <param name="local-network-acl" value="none"/>
+```
+
+so that FreeSWITCH announces the external IP address when a connection is established.
+
 Check `/etc/bigbluebutton/nginx/sip.nginx` to ensure its binding to the external IP address of the firewall [Configure FreeSWITCH for using SSL](/2.2/install.html#configure-freeswitch-for-using-ssl).
 
 Check that `enableListenOnly` is set to true in `/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml`, as in


### PR DESCRIPTION
… NAT

See the discussion in bigbluebutton/bigbluebutton.github.io#126 for full details. It boils down to:

WebSocket connections from the browser to FreeSWITCH always go through nginx. This means that FreeSWITCH only ever sees an internal IP if no dummy network interface with the public IP configured to it is used. As dummy network interfaces aren't required if one configures firewalls/routers to bounce locally-originating connections back properly, FreeSWITCH must be convinced differently that the origin is an external one, and that it should therefore announce its external IP.