### PR TITLE
Documentation for Pagination Support in getRecordings

### DIFF
--- a/_data/getRecordings.yml
+++ b/_data/getRecordings.yml
@@ -21,9 +21,9 @@
 - name: "page"
   required: false
   type: "Integer"
-  description: "The page number that you wish to retrieve. By default the first page (page 0) is returned."
+  description: "The page number that you wish to retrieve. By default the first page (page 0) is returned. Added in 2.6."
 
 - name: "size"
   required: false
   type: "Integer"
-  description: "The maximum number of recordings that should be returned per page. By default at most 25 recordings are included in each page." 
+  description: "The maximum number of recordings that should be returned per page. By default at most 25 recordings are included in each page. Added in 2.6." 

--- a/_data/getRecordings.yml
+++ b/_data/getRecordings.yml
@@ -17,3 +17,13 @@
   required: false
   type: "String"
   description: "You can pass one or more metadata values to filter the recordings returned. The format of these parameters is the same as the metadata passed to the <code class=\"language-plaintext highlighter-rouge\">create</code> call. For more information see <a href=\"https://docs.bigbluebutton.org/dev/api.html#create\">the docs for the create call</a>."
+
+- name: "page"
+  required: false
+  type: "Integer"
+  description: "The page number that you wish to retrieve. By default the first page (page 0) is returned."
+
+- name: "size"
+  required: false
+  type: "Integer"
+  description: "The maximum number of recordings that should be returned per page. By default at most 25 recordings are included in each page." 

--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -715,7 +715,7 @@ http&#58;//yourserver.com/bigbluebutton/api/getMeetings?checksum=1234
 
 ## getRecordings
 
-Retrieves the recordings that are available for playback for a given meetingID (or set of meeting IDs).
+Retrieves the recordings that are available for playback for a given meetingID (or set of meeting IDs). Support for pagination was added in 2.6.
 
 **Resource URL:**
 

--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -734,6 +734,7 @@ http&#58;//yourserver.com/bigbluebutton/api/getRecordings?[parameters]&checksum=
 - http&#58;//yourserver.com/bigbluebutton/api/getRecordings?recordID=652c9eb4c07ad49283554c76301d68770326bd93-1462283509434,9e359d17635e163c4388281567601d7fecf29df8-1461882579628&checksum=wxyz
 - http&#58;//yourserver.com/bigbluebutton/api/getRecordings?recordID=652c9eb4c07ad49283554c76301d68770326bd93&checksum=wxyz
 - http&#58;//yourserver.com/bigbluebutton/api/getRecordings?recordID=652c9eb4c07ad49283554c76301d68770326bd93,9e359d17635e163c4388281567601d7fecf29df8&checksum=wxyz
+- http&#58;//yourserver.com/bigbluebutton/api/getRecordings?state=published&page=2&size=10&checksum=abc123
 
 **Example Response:**
 
@@ -822,6 +823,25 @@ Here the `getRecordings` API call returned back two recordings for the meetingID
          </playback>
       </recording>
    </recordings>
+   <pagination>
+      <pageable>
+         <sort>
+            <unsorted>true</unsorted>
+            <sorted>false</sorted>
+            <empty>true</empty>
+          </sort>
+          <offset>0</offset>
+          <pageSize>25</pageSize>
+          <pageNumber>0</pageNumber>
+          <paged>true</paged>
+          <unpaged>false</unpaged>
+      <pageable>
+      <totalElements>2</totalElements>
+      <last>true</last>
+      <totalPages>1</totalPages>
+      <first>true</first>
+      <empty>false</empty>
+   </pagination>
 </response>
 ```
 


### PR DESCRIPTION
Added documentation for pagination support in getRecordings requests. This includes the addition of two pagination parameters `page` and `size` in the request as well as pagination data in the response.