### PR TITLE
Changed the bean format for securitySalt

### DIFF
--- a/_posts/admin/2019-02-14-customize.md
+++ b/_posts/admin/2019-02-14-customize.md
@@ -1381,7 +1381,7 @@ To validate incoming API calls, all external applications making API calls must 
 You’ll find the shared secret in `/etc/bigbluebutton/bbb-web.properties`
 
 ```properties
-beans.dynamicConferenceService.securitySalt=<value_of_salt>
+securitySalt=<value_of_salt>
 ```
 
 To change the shared secret, do the following:


### PR DESCRIPTION
https://github.com/bigbluebutton/bigbluebutton/blob/v2.5.x-release/bigbluebutton-web/grails-app/conf/bigbluebutton.properties#L331 looks like the format was changed in 2011 but the docs remained intact https://github.com/bigbluebutton/bigbluebutton/commit/8c8e009baabe8f2b6cb6701811eada97c162c9ad#diff-497ed85f0ee8170360c5c42a78c52810998253ce7d6ac49a8560007283dca31c