### PR TITLE
Documentation for supportedChecksumAlgorithms

### DIFF
--- a/_posts/dev/2015-04-05-api.md
+++ b/_posts/dev/2015-04-05-api.md
@@ -153,11 +153,13 @@ $ sudo bbb-conf --setsecret \$(openssl rand -base64 32 | sed 's/=//g' | sed 's/+
 
 There are other configuration values in bbb-web's configuration `bigbluebutton.properties` (overwritten by `/etc/bigbluebutton/bbb-web.properties` ) related to the lifecycle of a meeting. You don't need to understand all of these to start using the BigBlueButton API. For most BigBlueButton servers, you can leave the [default values](https://github.com/bigbluebutton/bigbluebutton/blob/main/bigbluebutton-web/grails-app/conf/bigbluebutton.properties).
 
+In 2.5 support for additional hashing algorithms, besides sha1 and sha256, were added. These include sha384 and sha512. The `supportedChecksumAlgorithms` property in `bigbluebutton.properties` defines which algorithms are supported. By default checksums can be validated with any of the supported algorithms. To remove support for one or more of these algorithms simply delete it from the configuration file.
+
 ## Usage
 
 The implementation of BigBlueButton's security model lies in the controller `ApiController.groovy`. For each incoming API request, the controller computes a checksum out of the combination of the entire HTTPS query string and the server's shared secret. It then matches the incoming checksum against the computed checksum. If they match, the controller accepts the incoming request.
 
-To use the security model, you must be able to create an SHA-1 checksum out of the call name _plus_ the query string _plus_ the shared secret that you configured on your server. To do so, follow these steps:
+To use the security model, you must be able to create a SHA-1 checksum out of the call name _plus_ the query string _plus_ the shared secret that you configured on your server. To do so, follow these steps:
 
 1. Create the entire query string for your API call without the checksum parameter.
    - Example for create meeting API call: `name=Test+Meeting&meetingID=abc123&attendeePW=111222&moderatorPW=333444`


### PR DESCRIPTION
Added documentation to the API section detailing the introduction of a new property in `bigbluebutton.properties` called `supportedChecksumAlgorithms` as well as support for sha384 and sha512 hashing algorithms to validate checksums.