### PR TITLE
Document allowFetchAllRecordings

### DIFF
--- a/_posts/admin/2019-02-14-customize.md
+++ b/_posts/admin/2019-02-14-customize.md
@@ -300,6 +300,10 @@ Persistent=false
 
 and do `systemctl daemon-reload`. This file overrides the timing of when systemd runs `bbb-record-core.target`. In the above example, recordings will start processing between 21:00 and 03:59.
 
+### Allow all recordings to be returned
+
+In 2.6.x a new configuration property, `allowFetchAllRecordings`, was added to `bigbluebutton.properties`. This property determines whether every recording on the server can be returned in a single response from a `getRecordings` call. By default this property is set to `true`. On a server with a large number of recordings an attempt to return every recording in a sinlge response can cause a large amount of load on the server and therefore it is advised that this property be switched to `false`. When this is done any request to `getRecordings` that does not specify any recording or meeting IDs as well as no pagination parameters will return no recordings to prevent all recordings from being returned. 
+
 ## Video
 
 ### Reduce bandwidth from webcams


### PR DESCRIPTION
Adds documentation for the new configuration property, `allowFetchAllRecordings`, in `bigbluebutton.properties`.